### PR TITLE
fix: remote spy blocking functionality and associated UI actions

### DIFF
--- a/scripts/executor-bridge.lua
+++ b/scripts/executor-bridge.lua
@@ -222,6 +222,8 @@ local bridgeAlive = true
 
 local remoteSpyEnabled = false
 local remoteSpyFilter = ''
+local remoteSpyBlockedNames = {}
+local remoteSpyBlockedPaths = {}
 local spyCleanup = nil
 
 -- Register this bridge instance globally for cleanup on re-execution
@@ -511,6 +513,35 @@ local serializeArguments = function(...)
 	local parts = {}
 	for i = 1, select('#', ...) do table.insert(parts, valueToLua(args[i])) end
 	return table.concat(parts, ', ')
+end
+
+local rebuildRemoteSpyBlockMaps = function(blocks)
+	remoteSpyBlockedNames = {}
+	remoteSpyBlockedPaths = {}
+
+	if type(blocks) ~= 'table' then return end
+
+	for _, entry in ipairs(blocks) do
+		if type(entry) ~= 'table' then continue end
+		if type(entry.type) ~= 'string' or type(entry.value) ~= 'string' then continue end
+
+		if entry.type == 'name' then
+			remoteSpyBlockedNames[entry.value] = true
+		elseif entry.type == 'path' then
+			remoteSpyBlockedPaths[entry.value] = true
+		end
+	end
+end
+
+local getRemoteBlockState = function(remote)
+	if typeof(remote) ~= 'Instance' then
+		return false, '', {}
+	end
+	local remotePath = getInstancePath(remote)
+	local remotePathString = table.concat(remotePath, '.')
+	local remoteName = remote.Name
+	local blocked = remoteSpyBlockedNames[remoteName] == true or remoteSpyBlockedPaths[remotePathString] == true
+	return blocked, remoteName, remotePath
 end
 
 --  Properties
@@ -921,7 +952,7 @@ MESSAGE_HANDLERS.setRemoteSpyEnabled = function(message)
 
 	local ok, err = pcall(function()
 		if message.enabled and not remoteSpyEnabled then
-			local logRemoteCall = function(self, method, ...)
+			local logRemoteCall = function(self, method, blocked, remoteName, remotePath, ...)
 				local args = { ... }
 				pcall(function()
 					if not remoteSpyEnabled or not connected then return end
@@ -930,19 +961,19 @@ MESSAGE_HANDLERS.setRemoteSpyEnabled = function(message)
 					local className = self.ClassName
 					if className ~= 'RemoteEvent' and className ~= 'RemoteFunction' and className ~= 'UnreliableRemoteEvent' then return end
 
-					local remoteName = self.Name
-					if remoteSpyFilter ~= '' and remoteName:lower():find(remoteSpyFilter:lower()) == nil then return end
+					if blocked ~= true and remoteSpyFilter ~= '' and remoteName:lower():find(remoteSpyFilter:lower()) == nil then return end
 
 					send({
 						type = 'remoteSpy',
 						call = {
 							remoteName = remoteName,
-							remotePath = getInstancePath(self),
+							remotePath = remotePath,
 							remoteType = className,
 							method = method,
 							arguments = serializeArguments(unpack(args)),
 							code = generateRemoteCode(self, method, unpack(args)),
 							timestamp = os.time(),
+							_blocked = blocked == true,
 						},
 					})
 				end)
@@ -955,7 +986,12 @@ MESSAGE_HANDLERS.setRemoteSpyEnabled = function(message)
 				oldNamecall = oth.hook(ncFunc, function(self, ...)
 					local method = getnamecallmethod()
 					if method == 'FireServer' or method == 'InvokeServer' then
-						logRemoteCall(self, method, ...)
+						local blocked, remoteName, remotePath = getRemoteBlockState(self)
+						logRemoteCall(self, method, blocked, remoteName, remotePath, ...)
+						if blocked then
+							setnamecallmethod(method)
+							return nil
+						end
 					end
 					setnamecallmethod(method)
 					return oldNamecall(self, ...)
@@ -975,7 +1011,12 @@ MESSAGE_HANDLERS.setRemoteSpyEnabled = function(message)
 				oldNamecall = hookmetamethod(game, '__namecall', newcclosure(function(self, ...)
 					local method = getnamecallmethod()
 					if method == 'FireServer' or method == 'InvokeServer' then
-						logRemoteCall(self, method, ...)
+						local blocked, remoteName, remotePath = getRemoteBlockState(self)
+						logRemoteCall(self, method, blocked, remoteName, remotePath, ...)
+						if blocked then
+							setnamecallmethod(method)
+							return nil
+						end
 					end
 					setnamecallmethod(method)
 					return oldNamecall(self, ...)
@@ -1010,6 +1051,11 @@ end
 MESSAGE_HANDLERS.setRemoteSpyFilter = function(message)
 	remoteSpyFilter = message.filter or ''
 	sendResult('setRemoteSpyFilterResult', message.id, true)
+end
+
+MESSAGE_HANDLERS.setRemoteSpyBlockList = function(message)
+	rebuildRemoteSpyBlockMaps(message.blocks)
+	sendResult('setRemoteSpyBlockListResult', message.id, true)
 end
 
 --  Core

--- a/tests/executor-bridge-remote-spy.test.ts
+++ b/tests/executor-bridge-remote-spy.test.ts
@@ -3,22 +3,29 @@ import path from 'path';
 
 import { describe, expect, test } from 'bun:test';
 
+const extractLuaHandler = (source: string, handlerName: string): string => {
+  const headerPattern = new RegExp(`MESSAGE_HANDLERS\\.${handlerName}\\s*=\\s*function\\s*\\(message\\)`);
+  const headerMatch = headerPattern.exec(source);
+  if (headerMatch === null || headerMatch.index === undefined) return '';
+
+  const bodyStart = headerMatch.index + headerMatch[0].length;
+  const nextHandlerMatch = /\nMESSAGE_HANDLERS\./g;
+  nextHandlerMatch.lastIndex = bodyStart;
+  const nextHandler = nextHandlerMatch.exec(source);
+  const bodyEnd = nextHandler?.index ?? source.length;
+  return source.slice(bodyStart, bodyEnd);
+};
+
 describe('Executor Bridge Remote Spy Blocking', () => {
   const filePath = path.join(import.meta.dir, '..', 'scripts', 'executor-bridge.lua');
   const source = readFileSync(filePath, 'utf8');
-  const setRemoteSpyBlockListHandlerMatch = source.match(
-    /MESSAGE_HANDLERS\.setRemoteSpyBlockList\s*=\s*function\s*\(message\)([\s\S]*?)\nend/,
-  );
-  const setRemoteSpyEnabledHandlerMatch = source.match(
-    /MESSAGE_HANDLERS\.setRemoteSpyEnabled\s*=\s*function\s*\(message\)([\s\S]*?)\nend/,
-  );
-  const setRemoteSpyBlockListHandler = setRemoteSpyBlockListHandlerMatch?.[1] ?? '';
-  const setRemoteSpyEnabledHandler = setRemoteSpyEnabledHandlerMatch?.[1] ?? '';
+  const setRemoteSpyBlockListHandler = extractLuaHandler(source, 'setRemoteSpyBlockList');
+  const setRemoteSpyEnabledHandler = extractLuaHandler(source, 'setRemoteSpyEnabled');
 
   test('stores and acknowledges the remote spy block list', () => {
     expect(/local\s+remoteSpyBlockedNames\s*=\s*\{\}/.test(source)).toBe(true);
     expect(/local\s+remoteSpyBlockedPaths\s*=\s*\{\}/.test(source)).toBe(true);
-    expect(setRemoteSpyBlockListHandlerMatch).toBeTruthy();
+    expect(setRemoteSpyBlockListHandler).not.toBe('');
     expect(/rebuildRemoteSpyBlockMaps\s*\(\s*message\.blocks\s*\)/.test(setRemoteSpyBlockListHandler)).toBe(true);
     expect(
       /sendResult\s*\(\s*'setRemoteSpyBlockListResult'\s*,\s*message\.id\s*,\s*true\s*\)/.test(
@@ -28,17 +35,28 @@ describe('Executor Bridge Remote Spy Blocking', () => {
   });
 
   test('short-circuits blocked remotes before forwarding to the original namecall', () => {
-    expect(setRemoteSpyEnabledHandlerMatch).toBeTruthy();
+    expect(setRemoteSpyEnabledHandler).not.toBe('');
     expect(
       /local\s+blocked\s*,\s*remoteName\s*,\s*remotePath\s*=\s*getRemoteBlockState\s*\(\s*self\s*\)/.test(
         setRemoteSpyEnabledHandler,
       ),
     ).toBe(true);
-    expect(/if\s+blocked\s+then[\s\S]*?return\s+nil/.test(setRemoteSpyEnabledHandler)).toBe(true);
+    const blockedBranchMatch = setRemoteSpyEnabledHandler.match(/if\s+blocked\s+then([\s\S]*?)end/);
+    const blockedBranch = blockedBranchMatch?.[1] ?? '';
+
+    expect(blockedBranch).not.toBe('');
+    expect(/return\s+nil/.test(blockedBranch)).toBe(true);
+    expect(/oldNamecall\s*\(/.test(blockedBranch)).toBe(false);
+
+    const blockedReturnIndex = setRemoteSpyEnabledHandler.indexOf('return nil');
+    const forwardCallIndex = setRemoteSpyEnabledHandler.indexOf('return oldNamecall(self, ...)');
+    expect(blockedReturnIndex).toBeGreaterThan(-1);
+    expect(forwardCallIndex).toBeGreaterThan(-1);
+    expect(blockedReturnIndex).toBeLessThan(forwardCallIndex);
   });
 
   test('marks blocked remote spy notifications for the UI', () => {
-    expect(setRemoteSpyEnabledHandlerMatch).toBeTruthy();
+    expect(setRemoteSpyEnabledHandler).not.toBe('');
     expect(/_blocked\s*=\s*blocked\s*==\s*true/.test(setRemoteSpyEnabledHandler)).toBe(true);
   });
 });

--- a/tests/executor-bridge-remote-spy.test.ts
+++ b/tests/executor-bridge-remote-spy.test.ts
@@ -4,27 +4,41 @@ import path from 'path';
 import { describe, expect, test } from 'bun:test';
 
 describe('Executor Bridge Remote Spy Blocking', () => {
-  const filePath = path.join(process.cwd(), 'scripts', 'executor-bridge.lua');
+  const filePath = path.join(import.meta.dir, '..', 'scripts', 'executor-bridge.lua');
   const source = readFileSync(filePath, 'utf8');
+  const setRemoteSpyBlockListHandlerMatch = source.match(
+    /MESSAGE_HANDLERS\.setRemoteSpyBlockList\s*=\s*function\s*\(message\)([\s\S]*?)\nend/,
+  );
+  const setRemoteSpyEnabledHandlerMatch = source.match(
+    /MESSAGE_HANDLERS\.setRemoteSpyEnabled\s*=\s*function\s*\(message\)([\s\S]*?)\nend/,
+  );
+  const setRemoteSpyBlockListHandler = setRemoteSpyBlockListHandlerMatch?.[1] ?? '';
+  const setRemoteSpyEnabledHandler = setRemoteSpyEnabledHandlerMatch?.[1] ?? '';
 
   test('stores and acknowledges the remote spy block list', () => {
     expect(/local\s+remoteSpyBlockedNames\s*=\s*\{\}/.test(source)).toBe(true);
     expect(/local\s+remoteSpyBlockedPaths\s*=\s*\{\}/.test(source)).toBe(true);
-    expect(/MESSAGE_HANDLERS\.setRemoteSpyBlockList\s*=\s*function\s*\(message\)/.test(source)).toBe(true);
-    expect(/rebuildRemoteSpyBlockMaps\s*\(\s*message\.blocks\s*\)/.test(source)).toBe(true);
-    expect(/sendResult\s*\(\s*'setRemoteSpyBlockListResult'\s*,\s*message\.id\s*,\s*true\s*\)/.test(source)).toBe(
-      true,
-    );
+    expect(setRemoteSpyBlockListHandlerMatch).toBeTruthy();
+    expect(/rebuildRemoteSpyBlockMaps\s*\(\s*message\.blocks\s*\)/.test(setRemoteSpyBlockListHandler)).toBe(true);
+    expect(
+      /sendResult\s*\(\s*'setRemoteSpyBlockListResult'\s*,\s*message\.id\s*,\s*true\s*\)/.test(
+        setRemoteSpyBlockListHandler,
+      ),
+    ).toBe(true);
   });
 
   test('short-circuits blocked remotes before forwarding to the original namecall', () => {
-    expect(/local\s+blocked\s*,\s*remoteName\s*,\s*remotePath\s*=\s*getRemoteBlockState\s*\(\s*self\s*\)/.test(source)).toBe(
-      true,
-    );
-    expect(/if\s+blocked\s+then[\s\S]*?return\s+nil/.test(source)).toBe(true);
+    expect(setRemoteSpyEnabledHandlerMatch).toBeTruthy();
+    expect(
+      /local\s+blocked\s*,\s*remoteName\s*,\s*remotePath\s*=\s*getRemoteBlockState\s*\(\s*self\s*\)/.test(
+        setRemoteSpyEnabledHandler,
+      ),
+    ).toBe(true);
+    expect(/if\s+blocked\s+then[\s\S]*?return\s+nil/.test(setRemoteSpyEnabledHandler)).toBe(true);
   });
 
   test('marks blocked remote spy notifications for the UI', () => {
-    expect(/_blocked\s*=\s*blocked\s*==\s*true/.test(source)).toBe(true);
+    expect(setRemoteSpyEnabledHandlerMatch).toBeTruthy();
+    expect(/_blocked\s*=\s*blocked\s*==\s*true/.test(setRemoteSpyEnabledHandler)).toBe(true);
   });
 });

--- a/tests/executor-bridge-remote-spy.test.ts
+++ b/tests/executor-bridge-remote-spy.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { describe, expect, test } from 'bun:test';
+
+describe('Executor Bridge Remote Spy Blocking', () => {
+  const filePath = path.join(process.cwd(), 'scripts', 'executor-bridge.lua');
+  const source = readFileSync(filePath, 'utf8');
+
+  test('stores and acknowledges the remote spy block list', () => {
+    expect(source.includes('local remoteSpyBlockedNames = {}')).toBe(true);
+    expect(source.includes('local remoteSpyBlockedPaths = {}')).toBe(true);
+    expect(source.includes('MESSAGE_HANDLERS.setRemoteSpyBlockList = function(message)')).toBe(true);
+    expect(source.includes("rebuildRemoteSpyBlockMaps(message.blocks)")).toBe(true);
+    expect(source.includes("sendResult('setRemoteSpyBlockListResult', message.id, true)")).toBe(true);
+  });
+
+  test('short-circuits blocked remotes before forwarding to the original namecall', () => {
+    expect(source.includes('local blocked, remoteName, remotePath = getRemoteBlockState(self)')).toBe(true);
+    expect(source.includes('if blocked then')).toBe(true);
+    expect(source.includes('return nil')).toBe(true);
+  });
+
+  test('marks blocked remote spy notifications for the UI', () => {
+    expect(source.includes('_blocked = blocked == true')).toBe(true);
+  });
+});

--- a/tests/executor-bridge-remote-spy.test.ts
+++ b/tests/executor-bridge-remote-spy.test.ts
@@ -8,20 +8,23 @@ describe('Executor Bridge Remote Spy Blocking', () => {
   const source = readFileSync(filePath, 'utf8');
 
   test('stores and acknowledges the remote spy block list', () => {
-    expect(source.includes('local remoteSpyBlockedNames = {}')).toBe(true);
-    expect(source.includes('local remoteSpyBlockedPaths = {}')).toBe(true);
-    expect(source.includes('MESSAGE_HANDLERS.setRemoteSpyBlockList = function(message)')).toBe(true);
-    expect(source.includes("rebuildRemoteSpyBlockMaps(message.blocks)")).toBe(true);
-    expect(source.includes("sendResult('setRemoteSpyBlockListResult', message.id, true)")).toBe(true);
+    expect(/local\s+remoteSpyBlockedNames\s*=\s*\{\}/.test(source)).toBe(true);
+    expect(/local\s+remoteSpyBlockedPaths\s*=\s*\{\}/.test(source)).toBe(true);
+    expect(/MESSAGE_HANDLERS\.setRemoteSpyBlockList\s*=\s*function\s*\(message\)/.test(source)).toBe(true);
+    expect(/rebuildRemoteSpyBlockMaps\s*\(\s*message\.blocks\s*\)/.test(source)).toBe(true);
+    expect(/sendResult\s*\(\s*'setRemoteSpyBlockListResult'\s*,\s*message\.id\s*,\s*true\s*\)/.test(source)).toBe(
+      true,
+    );
   });
 
   test('short-circuits blocked remotes before forwarding to the original namecall', () => {
-    expect(source.includes('local blocked, remoteName, remotePath = getRemoteBlockState(self)')).toBe(true);
-    expect(source.includes('if blocked then')).toBe(true);
-    expect(source.includes('return nil')).toBe(true);
+    expect(/local\s+blocked\s*,\s*remoteName\s*,\s*remotePath\s*=\s*getRemoteBlockState\s*\(\s*self\s*\)/.test(source)).toBe(
+      true,
+    );
+    expect(/if\s+blocked\s+then[\s\S]*?return\s+nil/.test(source)).toBe(true);
   });
 
   test('marks blocked remote spy notifications for the UI', () => {
-    expect(source.includes('_blocked = blocked == true')).toBe(true);
+    expect(/_blocked\s*=\s*blocked\s*==\s*true/.test(source)).toBe(true);
   });
 });

--- a/tests/remote-spy-webview.test.ts
+++ b/tests/remote-spy-webview.test.ts
@@ -10,11 +10,11 @@ describe('Remote Spy Webview - Markup Regression', () => {
     const filePath = path.join(process.cwd(), 'vscode', 'src', 'remoteSpyWebview.ts');
     const source = readFileSync(filePath, 'utf8');
 
-    expect(source.includes('onclick=')).toBe(false);
-    expect(source.includes('oninput=')).toBe(false);
-    expect(source.includes('data-action="copyCode"')).toBe(true);
-    expect(source.includes('data-action="copyPath"')).toBe(true);
-    expect(source.includes('data-action="copyArgs"')).toBe(true);
+    expect(/\bonclick\s*=/i.test(source)).toBe(false);
+    expect(/\boninput\s*=/i.test(source)).toBe(false);
+    expect(/<button[^>]*\bdata-action\s*=\s*"copyCode"/i.test(source)).toBe(true);
+    expect(/<button[^>]*\bdata-action\s*=\s*"copyPath"/i.test(source)).toBe(true);
+    expect(/<button[^>]*\bdata-action\s*=\s*"copyArgs"/i.test(source)).toBe(true);
   });
 });
 

--- a/tests/remote-spy-webview.test.ts
+++ b/tests/remote-spy-webview.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { describe, expect, test } from 'bun:test';
+
+import { dispatchRemoteSpyAction } from '../vscode/src/remoteSpyWebviewActions';
+
+describe('Remote Spy Webview - Markup Regression', () => {
+  test('webview does not use inline event handlers', () => {
+    const filePath = path.join(process.cwd(), 'vscode', 'src', 'remoteSpyWebview.ts');
+    const source = readFileSync(filePath, 'utf8');
+
+    expect(source.includes('onclick=')).toBe(false);
+    expect(source.includes('oninput=')).toBe(false);
+    expect(source.includes('data-action="copyCode"')).toBe(true);
+    expect(source.includes('data-action="copyPath"')).toBe(true);
+    expect(source.includes('data-action="copyArgs"')).toBe(true);
+  });
+});
+
+describe('Remote Spy Webview - Action Dispatch', () => {
+  const baseContext = {
+    'selectedIndex': 3,
+    'paused': false,
+    'spyEnabled': false,
+    'listsMode': null as 'ignores' | 'blocks' | null,
+  };
+
+  test('toggleSpy enables the spy when it is currently disabled', () => {
+    const result = dispatchRemoteSpyAction(baseContext, { 'action': 'toggleSpy' });
+    expect(result.messages).toEqual([{ 'type': 'toggleSpy', 'enabled': true }]);
+  });
+
+  test('togglePause pauses when active and resumes when paused', () => {
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'togglePause' }).messages).toEqual([{ 'type': 'pause' }]);
+    expect(dispatchRemoteSpyAction({ ...baseContext, 'paused': true }, { 'action': 'togglePause' }).messages).toEqual([
+      { 'type': 'resume' },
+    ]);
+  });
+
+  test('clearCalls sends clear message', () => {
+    const result = dispatchRemoteSpyAction(baseContext, { 'action': 'clearCalls' });
+    expect(result.messages).toEqual([{ 'type': 'clear' }]);
+  });
+
+  test('toggleListsPanel opens and closes ignore and block panels', () => {
+    expect(
+      dispatchRemoteSpyAction(baseContext, { 'action': 'toggleListsPanel', 'listMode': 'ignores' }).nextListsMode,
+    ).toBe('ignores');
+    expect(
+      dispatchRemoteSpyAction(
+        { ...baseContext, 'listsMode': 'ignores' },
+        { 'action': 'toggleListsPanel', 'listMode': 'ignores' },
+      ).nextListsMode,
+    ).toBe(null);
+    expect(
+      dispatchRemoteSpyAction(
+        { ...baseContext, 'listsMode': 'ignores' },
+        { 'action': 'toggleListsPanel', 'listMode': 'blocks' },
+      ).nextListsMode,
+    ).toBe('blocks');
+  });
+
+  describe('Copy Actions', () => {
+    test('copyCode targets the selected call', () => {
+      const result = dispatchRemoteSpyAction(baseContext, { 'action': 'copyCode' });
+      expect(result.messages).toEqual([{ 'type': 'copyCode', 'index': 3 }]);
+    });
+
+    test('copyPath targets the selected call', () => {
+      const result = dispatchRemoteSpyAction(baseContext, { 'action': 'copyPath' });
+      expect(result.messages).toEqual([{ 'type': 'copyPath', 'index': 3 }]);
+    });
+
+    test('copyArgs targets the selected call', () => {
+      const result = dispatchRemoteSpyAction(baseContext, { 'action': 'copyArgs' });
+      expect(result.messages).toEqual([{ 'type': 'copyArgs', 'index': 3 }]);
+    });
+  });
+
+  test('ignore and block actions target the selected call', () => {
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'ignoreByPath' }).messages).toEqual([
+      { 'type': 'ignoreByPath', 'index': 3 },
+    ]);
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'ignoreByName' }).messages).toEqual([
+      { 'type': 'ignoreByName', 'index': 3 },
+    ]);
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'blockByPath' }).messages).toEqual([
+      { 'type': 'blockByPath', 'index': 3 },
+    ]);
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'blockByName' }).messages).toEqual([
+      { 'type': 'blockByName', 'index': 3 },
+    ]);
+  });
+
+  test('selection-dependent actions do nothing when no call is selected', () => {
+    const noSelection = { ...baseContext, 'selectedIndex': -1 };
+
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'copyCode' }).messages).toEqual([]);
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'copyPath' }).messages).toEqual([]);
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'copyArgs' }).messages).toEqual([]);
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'ignoreByPath' }).messages).toEqual([]);
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'ignoreByName' }).messages).toEqual([]);
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'blockByPath' }).messages).toEqual([]);
+    expect(dispatchRemoteSpyAction(noSelection, { 'action': 'blockByName' }).messages).toEqual([]);
+  });
+
+  test('clear list actions emit their corresponding messages', () => {
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'clearIgnores' }).messages).toEqual([
+      { 'type': 'clearIgnores' },
+    ]);
+    expect(dispatchRemoteSpyAction(baseContext, { 'action': 'clearBlocks' }).messages).toEqual([
+      { 'type': 'clearBlocks' },
+    ]);
+  });
+
+  test('remove actions preserve the entry payload', () => {
+    expect(
+      dispatchRemoteSpyAction(baseContext, {
+        'action': 'removeIgnore',
+        'entryType': 'path',
+        'entryValue': 'ReplicatedStorage.Events.ChatEvent',
+      }).messages,
+    ).toEqual([
+      {
+        'type': 'removeIgnore',
+        'entry': { 'type': 'path', 'value': 'ReplicatedStorage.Events.ChatEvent' },
+      },
+    ]);
+
+    expect(
+      dispatchRemoteSpyAction(baseContext, {
+        'action': 'removeBlock',
+        'entryType': 'name',
+        'entryValue': 'ChatEvent',
+      }).messages,
+    ).toEqual([
+      {
+        'type': 'removeBlock',
+        'entry': { 'type': 'name', 'value': 'ChatEvent' },
+      },
+    ]);
+  });
+
+  test('remove actions reject invalid entry payloads', () => {
+    expect(
+      dispatchRemoteSpyAction(baseContext, {
+        'action': 'removeIgnore',
+        'entryType': 'invalid',
+        'entryValue': 'BadEntry',
+      }).messages,
+    ).toEqual([]);
+
+    expect(
+      dispatchRemoteSpyAction(baseContext, {
+        'action': 'removeBlock',
+        'entryType': 'path',
+        'entryValue': null,
+      }).messages,
+    ).toEqual([]);
+  });
+});

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -52,6 +52,7 @@ let lastClientType: string | undefined;
 const scriptDocumentPaths = new Map<string, string[]>();
 let isPollingExecutorStatus = false;
 let debugLoggingEnabled = false;
+let syncRemoteSpyStateToExecutor: () => Promise<void> = async () => {};
 
 const logDebug = (...args: unknown[]): void => {
   if (debugLoggingEnabled === false) return;
@@ -141,6 +142,7 @@ const pollExecutorStatus = async (): Promise<void> => {
       lastClientType = currentClientType;
       commands.executeCommand('setContext', 'rbxdev-ls:bridgeConnected', true);
       commands.executeCommand('setContext', 'rbxdev-ls:clientType', currentClientType ?? 'executor');
+      void syncRemoteSpyStateToExecutor();
     } else if (response.isConnected === false && lastConnectedState) {
       const label = lastClientType === 'studio' ? 'Roblox Studio' : (lastExecutorName ?? 'Client');
       window.showWarningMessage(`Roblox: ${label} disconnected`);
@@ -312,6 +314,18 @@ export const activate = (context: ExtensionContext): void => {
     } catch {
       /* noop */
     }
+  };
+
+  syncRemoteSpyStateToExecutor = async (): Promise<void> => {
+    if (remoteSpyEnabled) {
+      try {
+        await client.sendRequest('custom/setRemoteSpyEnabled', { 'enabled': true });
+      } catch {
+        /* noop */
+      }
+    }
+
+    if (remoteSpyState.blockList.length > 0) await sendBlockListToExecutor();
   };
 
   remoteSpyPanel.onMessage(async (message: FromWebviewMessage) => {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -317,15 +317,13 @@ export const activate = (context: ExtensionContext): void => {
   };
 
   syncRemoteSpyStateToExecutor = async (): Promise<void> => {
-    if (remoteSpyEnabled) {
-      try {
-        await client.sendRequest('custom/setRemoteSpyEnabled', { 'enabled': true });
-      } catch {
-        /* noop */
-      }
+    try {
+      await client.sendRequest('custom/setRemoteSpyEnabled', { 'enabled': remoteSpyEnabled });
+    } catch {
+      /* noop */
     }
 
-    if (remoteSpyState.blockList.length > 0) await sendBlockListToExecutor();
+    await sendBlockListToExecutor();
   };
 
   remoteSpyPanel.onMessage(async (message: FromWebviewMessage) => {

--- a/vscode/src/remoteSpyWebview.ts
+++ b/vscode/src/remoteSpyWebview.ts
@@ -817,7 +817,7 @@ export class RemoteSpyPanel {
           html += '<div class="list-entry">'
             + '<span class="entry-type">' + entry.type + '</span>'
             + '<span class="entry-value">' + escHtml(entry.value) + '</span>'
-            + '<button class="entry-remove" data-action="removeIgnore" data-entry-type="' + escAttr(entry.type) + '" data-entry-value="' + escAttr(entry.value) + '">x</button>'
+            + '<button class="entry-remove" aria-label="Remove ignored remote ' + escHtml(entry.value) + '" title="Remove ignored remote" data-action="removeIgnore" data-entry-type="' + escAttr(entry.type) + '" data-entry-value="' + escAttr(entry.value) + '">x</button>'
             + '</div>';
         }
         html += '<div style="padding:4px 10px;"><button class="btn" data-action="clearIgnores" style="width:100%;">Clear All Ignores</button></div>';
@@ -830,7 +830,7 @@ export class RemoteSpyPanel {
           html += '<div class="list-entry">'
             + '<span class="entry-type">' + entry.type + '</span>'
             + '<span class="entry-value">' + escHtml(entry.value) + '</span>'
-            + '<button class="entry-remove" data-action="removeBlock" data-entry-type="' + escAttr(entry.type) + '" data-entry-value="' + escAttr(entry.value) + '">x</button>'
+            + '<button class="entry-remove" aria-label="Remove blocked remote ' + escHtml(entry.value) + '" title="Remove blocked remote" data-action="removeBlock" data-entry-type="' + escAttr(entry.type) + '" data-entry-value="' + escAttr(entry.value) + '">x</button>'
             + '</div>';
         }
         html += '<div style="padding:4px 10px;"><button class="btn danger" data-action="clearBlocks" style="width:100%;">Clear All Blocks</button></div>';

--- a/vscode/src/remoteSpyWebview.ts
+++ b/vscode/src/remoteSpyWebview.ts
@@ -8,6 +8,7 @@ import { randomBytes } from 'crypto';
 import { Disposable, ExtensionContext, ViewColumn, WebviewPanel, window } from 'vscode';
 
 import type { BlockEntry, IgnoreEntry, RemoteSpyCallEntry, RemoteSpyState } from './remoteSpyState';
+import type { RemoteSpyWebviewMessage } from './remoteSpyWebviewActions';
 
 /**
  * Messages sent from the extension host to the WebView
@@ -22,30 +23,7 @@ export interface ToWebviewMessage {
 /**
  * Messages sent from the WebView to the extension host
  */
-export interface FromWebviewMessage {
-  readonly type:
-    | 'selectCall'
-    | 'copyCode'
-    | 'copyPath'
-    | 'copyArgs'
-    | 'ignoreByPath'
-    | 'ignoreByName'
-    | 'blockByPath'
-    | 'blockByName'
-    | 'clearIgnores'
-    | 'clearBlocks'
-    | 'pause'
-    | 'resume'
-    | 'toggleSpy'
-    | 'search'
-    | 'clear'
-    | 'removeIgnore'
-    | 'removeBlock';
-  readonly index?: number;
-  readonly query?: string;
-  readonly enabled?: boolean;
-  readonly entry?: IgnoreEntry | BlockEntry;
-}
+export type FromWebviewMessage = RemoteSpyWebviewMessage;
 
 interface WebviewStateSnapshot {
   readonly calls: ReadonlyArray<RemoteSpyCallEntry>;
@@ -552,6 +530,9 @@ export class RemoteSpyPanel {
       font-size: 11.5px;
     }
     .list-entry .entry-remove {
+      appearance: none;
+      background: transparent;
+      border: 0;
       cursor: pointer;
       color: var(--vscode-descriptionForeground);
       font-size: 16px;
@@ -604,16 +585,16 @@ export class RemoteSpyPanel {
 <body>
   <div class="toolbar">
     <div class="toolbar-group">
-      <button class="btn primary" id="btn-toggle" onclick="toggleSpy()">Enable Spy</button>
-      <button class="btn" id="btn-pause" onclick="togglePause()" disabled>Pause</button>
-      <button class="btn" id="btn-clear" onclick="clearCalls()">Clear</button>
+      <button class="btn primary" id="btn-toggle" data-action="toggleSpy">Enable Spy</button>
+      <button class="btn" id="btn-pause" data-action="togglePause" disabled>Pause</button>
+      <button class="btn" id="btn-clear" data-action="clearCalls">Clear</button>
     </div>
     <div class="toolbar-sep"></div>
     <div class="toolbar-group">
-      <button class="btn" id="btn-ignores" onclick="toggleListsPanel('ignores')">Ignores <span class="badge" id="ignore-count">0</span></button>
-      <button class="btn" id="btn-blocks" onclick="toggleListsPanel('blocks')">Blocks <span class="badge" id="block-count">0</span></button>
+      <button class="btn" id="btn-ignores" data-action="toggleListsPanel" data-list-mode="ignores">Ignores <span class="badge" id="ignore-count">0</span></button>
+      <button class="btn" id="btn-blocks" data-action="toggleListsPanel" data-list-mode="blocks">Blocks <span class="badge" id="block-count">0</span></button>
     </div>
-    <input type="text" class="search-box" id="search" placeholder="Search remotes..." oninput="onSearch(this.value)">
+    <input type="text" class="search-box" id="search" placeholder="Search remotes...">
   </div>
 
   <div class="main">
@@ -629,15 +610,15 @@ export class RemoteSpyPanel {
         <span id="code-header-text">Code</span>
       </div>
       <div class="code-actions" id="code-actions" style="display:none;">
-        <button class="btn" onclick="copyCode()">Copy Code</button>
-        <button class="btn" onclick="copyPath()">Copy Path</button>
-        <button class="btn" onclick="copyArgs()">Copy Args</button>
+        <button class="btn" data-action="copyCode">Copy Code</button>
+        <button class="btn" data-action="copyPath">Copy Path</button>
+        <button class="btn" data-action="copyArgs">Copy Args</button>
         <div class="toolbar-sep"></div>
-        <button class="btn" onclick="ignoreByPath()">Ignore Path</button>
-        <button class="btn" onclick="ignoreByName()">Ignore Name</button>
+        <button class="btn" data-action="ignoreByPath">Ignore Path</button>
+        <button class="btn" data-action="ignoreByName">Ignore Name</button>
         <div class="toolbar-sep"></div>
-        <button class="btn danger" onclick="blockByPath()">Block Path</button>
-        <button class="btn danger" onclick="blockByName()">Block Name</button>
+        <button class="btn danger" data-action="blockByPath">Block Path</button>
+        <button class="btn danger" data-action="blockByName">Block Name</button>
       </div>
       <div class="code-empty" id="code-empty">
         <div class="code-empty-icon">{ }</div>
@@ -775,7 +756,7 @@ export class RemoteSpyPanel {
         const typeClass = getCallClass(call);
         const selected = realIndex === state.selectedIndex ? ' selected' : '';
         const blocked = call._blocked ? ' blocked' : '';
-        html += '<div class="call-item ' + typeClass + selected + blocked + '" data-index="' + realIndex + '" onclick="selectCall(' + realIndex + ')">'
+        html += '<div class="call-item ' + typeClass + selected + blocked + '" data-index="' + realIndex + '">'
           + '<div class="call-info">'
           + '<div class="call-name">' + escHtml(call.remoteName) + '</div>'
           + '<div class="call-meta">'
@@ -836,10 +817,10 @@ export class RemoteSpyPanel {
           html += '<div class="list-entry">'
             + '<span class="entry-type">' + entry.type + '</span>'
             + '<span class="entry-value">' + escHtml(entry.value) + '</span>'
-            + '<span class="entry-remove" onclick="removeIgnoreEntry(\\'' + escAttr(entry.type) + '\\', \\'' + escAttr(entry.value) + '\\')">x</span>'
+            + '<button class="entry-remove" data-action="removeIgnore" data-entry-type="' + escAttr(entry.type) + '" data-entry-value="' + escAttr(entry.value) + '">x</button>'
             + '</div>';
         }
-        html += '<div style="padding:4px 10px;"><button class="btn" onclick="doClearIgnores()" style="width:100%;">Clear All Ignores</button></div>';
+        html += '<div style="padding:4px 10px;"><button class="btn" data-action="clearIgnores" style="width:100%;">Clear All Ignores</button></div>';
       } else if (state.listsMode === 'blocks') {
         html += '<div class="list-header">Blocked Remotes (' + state.blockList.length + ')</div>';
         if (state.blockList.length === 0) {
@@ -849,10 +830,10 @@ export class RemoteSpyPanel {
           html += '<div class="list-entry">'
             + '<span class="entry-type">' + entry.type + '</span>'
             + '<span class="entry-value">' + escHtml(entry.value) + '</span>'
-            + '<span class="entry-remove" onclick="removeBlockEntry(\\'' + escAttr(entry.type) + '\\', \\'' + escAttr(entry.value) + '\\')">x</span>'
+            + '<button class="entry-remove" data-action="removeBlock" data-entry-type="' + escAttr(entry.type) + '" data-entry-value="' + escAttr(entry.value) + '">x</button>'
             + '</div>';
         }
-        html += '<div style="padding:4px 10px;"><button class="btn danger" onclick="doClearBlocks()" style="width:100%;">Clear All Blocks</button></div>';
+        html += '<div style="padding:4px 10px;"><button class="btn danger" data-action="clearBlocks" style="width:100%;">Clear All Blocks</button></div>';
       }
       panel.innerHTML = html;
     };
@@ -898,7 +879,12 @@ export class RemoteSpyPanel {
     };
     const escAttr = (s) => {
       if (typeof s !== 'string') return '';
-      return s.replace(/\\\\/g, '\\\\\\\\').replace(/'/g, "\\\\'");
+      return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
     };
 
     const selectCall = (index) => {
@@ -944,16 +930,6 @@ export class RemoteSpyPanel {
       if (state.selectedIndex >= 0) vscode.postMessage({ type: 'blockByName', index: state.selectedIndex });
     };
 
-    const doClearIgnores = () => { vscode.postMessage({ type: 'clearIgnores' }); };
-    const doClearBlocks = () => { vscode.postMessage({ type: 'clearBlocks' }); };
-
-    const removeIgnoreEntry = (type, value) => {
-      vscode.postMessage({ type: 'removeIgnore', entry: { type, value } });
-    };
-    const removeBlockEntry = (type, value) => {
-      vscode.postMessage({ type: 'removeBlock', entry: { type, value } });
-    };
-
     const toggleListsPanel = (mode) => {
       state.listsMode = state.listsMode === mode ? null : mode;
       renderListsPanel();
@@ -969,6 +945,87 @@ export class RemoteSpyPanel {
     callListEl.addEventListener('scroll', () => {
       const atBottom = callListEl.scrollHeight - callListEl.scrollTop - callListEl.clientHeight < 40;
       shouldAutoScroll = atBottom;
+    });
+
+    document.addEventListener('click', (event) => {
+      const eventTarget = event.target;
+      const eventElement =
+        eventTarget instanceof Element ? eventTarget : eventTarget instanceof Node ? eventTarget.parentElement : null;
+      const target = eventElement?.closest('[data-action], .call-item') ?? null;
+      if (target === null) return;
+
+      if (target.classList.contains('call-item')) {
+        const index = Number(target.getAttribute('data-index'));
+        if (Number.isInteger(index)) selectCall(index);
+        return;
+      }
+
+      const action = target.getAttribute('data-action');
+      if (action === null) return;
+
+      switch (action) {
+        case 'toggleSpy':
+          toggleSpy();
+          break;
+        case 'togglePause':
+          togglePause();
+          break;
+        case 'clearCalls':
+          clearCalls();
+          break;
+        case 'toggleListsPanel': {
+          const mode = target.getAttribute('data-list-mode');
+          if (mode === 'ignores' || mode === 'blocks') {
+            toggleListsPanel(mode);
+          }
+          break;
+        }
+        case 'copyCode':
+          copyCode();
+          break;
+        case 'copyPath':
+          copyPath();
+          break;
+        case 'copyArgs':
+          copyArgs();
+          break;
+        case 'ignoreByPath':
+          ignoreByPath();
+          break;
+        case 'ignoreByName':
+          ignoreByName();
+          break;
+        case 'blockByPath':
+          blockByPath();
+          break;
+        case 'blockByName':
+          blockByName();
+          break;
+        case 'clearIgnores':
+          vscode.postMessage({ 'type': 'clearIgnores' });
+          break;
+        case 'clearBlocks':
+          vscode.postMessage({ 'type': 'clearBlocks' });
+          break;
+        case 'removeIgnore':
+        case 'removeBlock': {
+          const type = target.getAttribute('data-entry-type');
+          const value = target.getAttribute('data-entry-value');
+          if ((type === 'name' || type === 'path') && value !== null) {
+            vscode.postMessage({
+              'type': action === 'removeIgnore' ? 'removeIgnore' : 'removeBlock',
+              'entry': { type, value },
+            });
+          }
+          break;
+        }
+      }
+    });
+
+    const searchInput = document.getElementById('search');
+    searchInput.addEventListener('input', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement) onSearch(target.value);
     });
 
     window.addEventListener('message', (event) => {

--- a/vscode/src/remoteSpyWebviewActions.ts
+++ b/vscode/src/remoteSpyWebviewActions.ts
@@ -1,0 +1,144 @@
+import type { BlockEntry, IgnoreEntry } from './remoteSpyState';
+
+export type RemoteSpyWebviewAction =
+  | 'toggleSpy'
+  | 'togglePause'
+  | 'clearCalls'
+  | 'toggleListsPanel'
+  | 'copyCode'
+  | 'copyPath'
+  | 'copyArgs'
+  | 'ignoreByPath'
+  | 'ignoreByName'
+  | 'blockByPath'
+  | 'blockByName'
+  | 'clearIgnores'
+  | 'clearBlocks'
+  | 'removeIgnore'
+  | 'removeBlock';
+
+export type RemoteSpyListMode = 'ignores' | 'blocks' | null;
+
+export interface RemoteSpyWebviewMessage {
+  readonly type:
+    | 'selectCall'
+    | 'copyCode'
+    | 'copyPath'
+    | 'copyArgs'
+    | 'ignoreByPath'
+    | 'ignoreByName'
+    | 'blockByPath'
+    | 'blockByName'
+    | 'clearIgnores'
+    | 'clearBlocks'
+    | 'pause'
+    | 'resume'
+    | 'toggleSpy'
+    | 'search'
+    | 'clear'
+    | 'removeIgnore'
+    | 'removeBlock';
+  readonly index?: number;
+  readonly query?: string;
+  readonly enabled?: boolean;
+  readonly entry?: IgnoreEntry | BlockEntry;
+}
+
+export interface RemoteSpyActionContext {
+  readonly selectedIndex: number;
+  readonly paused: boolean;
+  readonly spyEnabled: boolean;
+  readonly listsMode: RemoteSpyListMode;
+}
+
+export interface RemoteSpyActionPayload {
+  readonly action: RemoteSpyWebviewAction;
+  readonly listMode?: string | null;
+  readonly entryType?: string | null;
+  readonly entryValue?: string | null;
+}
+
+export interface RemoteSpyActionResult {
+  readonly nextListsMode: RemoteSpyListMode;
+  readonly messages: ReadonlyArray<RemoteSpyWebviewMessage>;
+}
+
+const createIndexedMessage = (
+  type: 'copyCode' | 'copyPath' | 'copyArgs' | 'ignoreByPath' | 'ignoreByName' | 'blockByPath' | 'blockByName',
+  selectedIndex: number,
+): RemoteSpyWebviewMessage[] => {
+  if (selectedIndex < 0) return [];
+  return [{ type, 'index': selectedIndex }];
+};
+
+const isListMode = (value: string | null | undefined): value is Exclude<RemoteSpyListMode, null> =>
+  value === 'ignores' || value === 'blocks';
+
+const isEntryType = (value: string | null | undefined): value is 'name' | 'path' => value === 'name' || value === 'path';
+
+export const dispatchRemoteSpyAction = (
+  context: RemoteSpyActionContext,
+  payload: RemoteSpyActionPayload,
+): RemoteSpyActionResult => {
+  switch (payload.action) {
+    case 'toggleSpy':
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': [{ 'type': 'toggleSpy', 'enabled': context.spyEnabled === false }],
+      };
+    case 'togglePause':
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': [{ 'type': context.paused ? 'resume' : 'pause' }],
+      };
+    case 'clearCalls':
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': [{ 'type': 'clear' }],
+      };
+    case 'toggleListsPanel': {
+      const nextListsMode =
+        isListMode(payload.listMode) && context.listsMode !== payload.listMode ? payload.listMode : null;
+      return { nextListsMode, 'messages': [] };
+    }
+    case 'copyCode':
+    case 'copyPath':
+    case 'copyArgs':
+    case 'ignoreByPath':
+    case 'ignoreByName':
+    case 'blockByPath':
+    case 'blockByName':
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': createIndexedMessage(payload.action, context.selectedIndex),
+      };
+    case 'clearIgnores':
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': [{ 'type': 'clearIgnores' }],
+      };
+    case 'clearBlocks':
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': [{ 'type': 'clearBlocks' }],
+      };
+    case 'removeIgnore':
+    case 'removeBlock': {
+      if (isEntryType(payload.entryType) === false || payload.entryValue === undefined || payload.entryValue === null) {
+        return { 'nextListsMode': context.listsMode, 'messages': [] };
+      }
+      return {
+        'nextListsMode': context.listsMode,
+        'messages': [
+          {
+            'type': payload.action,
+            'entry': {
+              'type': payload.entryType,
+              'value': payload.entryValue,
+            },
+          },
+        ],
+      };
+    }
+  }
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block remote-spy targets by name or path; blocked calls are flagged (_blocked) and block lists are synchronized to the executor on connect.  
  * Remote Spy webview refactored to action-based handlers (toggle, pause/resume, copy, ignore/block, remove, clear, search) with richer state (selection, paused, lists counts).

* **Tests**
  * Added tests for block-list handling, executor short‑circuit behavior, UI action dispatches, and webview interaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->