### PR TITLE
Fix executor bridge disconnect lag

### DIFF
--- a/scripts/executor-bridge.lua
+++ b/scripts/executor-bridge.lua
@@ -1202,9 +1202,13 @@ scheduleReconnect = function()
 
 		if connected or not isBridgeAlive() then return end
 
-		local didConnect = connect(false)
-		if didConnect then
+		local connectState = connect(false)
+		if connectState == 'connected' then
 			reconnectAttemptDelay = CONFIG.reconnectDelay
+			return
+		end
+		if connectState == 'blocked' then
+			scheduleReconnect()
 			return
 		end
 
@@ -1227,7 +1231,7 @@ connect = function(scheduleOnFailure)
 		if scheduleOnFailure then
 			scheduleReconnect()
 		end
-		return false
+		return 'blocked'
 	end
 
 	local ok, ws = pcall(WebSocket.connect, CONFIG.host)
@@ -1235,7 +1239,7 @@ connect = function(scheduleOnFailure)
 		if scheduleOnFailure then
 			scheduleReconnect()
 		end
-		return false
+		return 'failed'
 	end
 
 	connection = ws
@@ -1259,7 +1263,7 @@ connect = function(scheduleOnFailure)
 		scheduleReconnect()
 	end)
 
-	return true
+	return 'connected'
 end
 
 task.defer(connect)

--- a/scripts/executor-bridge.lua
+++ b/scripts/executor-bridge.lua
@@ -15,6 +15,8 @@ local userConfig = (...) or {}
 local CONFIG = {
 	host              = 'ws://127.0.0.1:21324',
 	reconnectDelay    = 5,
+	reconnectDelayMax = 60,
+	enableHealthProbe = true,
 	firstConnectDepth = 999,
 	updateTreeDepth   = 3,
 	expandedTreeDepth = 2,
@@ -202,6 +204,12 @@ local WebSocket = WebSocket
 	or (Xeno and Xeno.websocket)
 	or websocket
 
+local HttpRequest = request
+	or http_request
+	or syn_request
+	or (syn and syn.request)
+	or (http and http.request)
+
 if WebSocket == nil then
 	warn'[rbxdev-bridge] No WebSocket implementation found!'
 	return
@@ -219,6 +227,9 @@ local connection = nil
 local connected = false
 local refreshConnections = {}
 local bridgeAlive = true
+local reconnectScheduled = false
+local reconnectAttemptDelay = CONFIG.reconnectDelay
+local healthProbeFailures = 0
 
 local remoteSpyEnabled = false
 local remoteSpyFilter = ''
@@ -253,6 +264,50 @@ local jsonDecode = function(data)
 	local success, result = pcall(HttpService.JSONDecode, HttpService, data)
 	if not success then return nil end
 	return result
+end
+
+local getHealthUrl = function()
+	if type(CONFIG.healthUrl) == 'string' and CONFIG.healthUrl ~= '' then
+		return CONFIG.healthUrl
+	end
+
+	local base = CONFIG.host:gsub('^wss://', 'https://'):gsub('^ws://', 'http://')
+	local origin = base:match'^(https?://[^/]+)'
+	if origin == nil then return nil end
+	return origin .. '/health'
+end
+
+local canAttemptConnect = function()
+	if CONFIG.enableHealthProbe == false or HttpRequest == nil then
+		return true
+	end
+
+	local healthUrl = getHealthUrl()
+	if healthUrl == nil then
+		return true
+	end
+
+	local ok, response = pcall(HttpRequest, {
+		Url = healthUrl,
+		Method = 'GET',
+		Headers = {
+			['Cache-Control'] = 'no-cache',
+		},
+	})
+
+	if not ok or type(response) ~= 'table' then
+		healthProbeFailures = healthProbeFailures + 1
+		return healthProbeFailures % 3 == 0
+	end
+
+	local statusCode = response.StatusCode or response.Status or response.status_code
+	if statusCode == 200 then
+		healthProbeFailures = 0
+		return true
+	end
+
+	healthProbeFailures = healthProbeFailures + 1
+	return healthProbeFailures % 3 == 0
 end
 
 local send = function(data)
@@ -1134,20 +1189,60 @@ end
 
 
 local connect
-connect = function()
+local scheduleReconnect
+
+scheduleReconnect = function()
+	if reconnectScheduled or connected or not isBridgeAlive() then return end
+
+	reconnectScheduled = true
+	local delay = math.max(0, reconnectAttemptDelay or CONFIG.reconnectDelay or 0)
+
+	task.delay(delay, function()
+		reconnectScheduled = false
+
+		if connected or not isBridgeAlive() then return end
+
+		local didConnect = connect(false)
+		if didConnect then
+			reconnectAttemptDelay = CONFIG.reconnectDelay
+			return
+		end
+
+		local nextDelay = reconnectAttemptDelay
+		if nextDelay == nil or nextDelay <= 0 then
+			nextDelay = CONFIG.reconnectDelay
+		elseif nextDelay < CONFIG.reconnectDelayMax then
+			nextDelay = math.min(nextDelay * 2, CONFIG.reconnectDelayMax)
+		end
+
+		reconnectAttemptDelay = nextDelay
+		scheduleReconnect()
+	end)
+end
+
+connect = function(scheduleOnFailure)
 	if not isBridgeAlive() then return false end
+	if scheduleOnFailure == nil then scheduleOnFailure = true end
+	if not canAttemptConnect() then
+		if scheduleOnFailure then
+			scheduleReconnect()
+		end
+		return false
+	end
 
 	local ok, ws = pcall(WebSocket.connect, CONFIG.host)
 	if not ok or ws == nil then
-		-- Retry after delay (handles VS Code restart where server isn't ready yet)
-		task.delay(CONFIG.reconnectDelay, function()
-			if not connected and isBridgeAlive() then connect() end
-		end)
+		if scheduleOnFailure then
+			scheduleReconnect()
+		end
 		return false
 	end
 
 	connection = ws
 	connected = true
+	reconnectScheduled = false
+	reconnectAttemptDelay = CONFIG.reconnectDelay
+	healthProbeFailures = 0
 
 	if getgenv and getgenv()._RBXDEV_BRIDGE then
 		getgenv()._RBXDEV_BRIDGE.connection = ws
@@ -1161,13 +1256,11 @@ connect = function()
 	ws.OnClose:Connect(function()
 		connected = false
 		connection = nil
-		task.delay(CONFIG.reconnectDelay, function()
-			if not connected and isBridgeAlive() then connect() end
-		end)
+		scheduleReconnect()
 	end)
 
 	return true
 end
 
-connect()
+task.defer(connect)
 setupLogHooks()

--- a/src/executor/server.ts
+++ b/src/executor/server.ts
@@ -1,3 +1,4 @@
+import { createServer, type IncomingMessage, type Server as HttpServer } from 'node:http';
 import { WebSocket, WebSocketServer } from 'ws';
 
 import type { ExecutorBridge } from '@typings/bridge';
@@ -16,6 +17,7 @@ const isProxyStatusChange = (msg: unknown): msg is ProxyStatusChangeMessage =>
 
 /** Creates a new executor bridge instance for managing WebSocket connections with Roblox executors. */
 export const createExecutorBridge = (log: (message: string) => void): ExecutorBridge => {
+  let httpServer: HttpServer | undefined;
   let server: WebSocketServer | undefined;
   let executorClient: WebSocket | undefined;
   let handshakeTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -245,14 +247,45 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
   };
 
   const start = (port: number): void => {
-    if (server !== undefined || isProxyMode) return;
+    if (httpServer !== undefined || server !== undefined || isProxyMode) return;
 
     setServerTransport();
 
     try {
-      server = new WebSocketServer({ 'host': '127.0.0.1', port });
+      httpServer = createServer((req, res) => {
+        if (req.method === 'GET' && req.url === '/health') {
+          const payload = JSON.stringify({
+            'ok': true,
+            'connected': core.getStatus() === 'connected',
+            'executorName': core.getExecutorName(),
+            'clientType': core.getClientType(),
+          });
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            'Cache-Control': 'no-store',
+          });
+          res.end(payload);
+          return;
+        }
+
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+      });
+
+      server = new WebSocketServer({ 'noServer': true });
       core.setStatus('waiting');
-      log(`[bridge] WebSocket server started on port ${port}`);
+
+      httpServer.on('upgrade', (req: IncomingMessage, socket, head) => {
+        if (server === undefined) {
+          socket.destroy();
+          return;
+        }
+
+        server.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+          server?.emit('connection', ws, req);
+        });
+      });
 
       server.on('connection', (ws: WebSocket) => {
         ws.once('message', (data: Buffer | string) => {
@@ -285,6 +318,30 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
         }
         log(`[bridge] Server error: ${err.message}`);
         core.setStatus('error');
+      });
+
+      httpServer.on('error', (err: Error & { code?: string }) => {
+        if (err.code === 'EADDRINUSE' && isProxyMode === false) {
+          try {
+            server?.close();
+          } catch {
+            /* noop */
+          }
+          try {
+            httpServer?.close();
+          } catch {
+            /* noop */
+          }
+          server = undefined;
+          httpServer = undefined;
+          startAsProxy(port);
+          return;
+        }
+        log(`[bridge] HTTP server error: ${err.message}`);
+        core.setStatus('error');
+      });
+      httpServer.listen(port, '127.0.0.1', () => {
+        log(`[bridge] WebSocket server started on port ${port}`);
       });
     } catch (err) {
       log(`[bridge] Failed to start server: ${err instanceof Error ? err.message : String(err)}`);
@@ -320,6 +377,10 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
       server.close();
       server = undefined;
     }
+    if (httpServer !== undefined) {
+      httpServer.close();
+      httpServer = undefined;
+    }
     core.setExecutorName(undefined);
     core.setConnected(false);
     core.setStatus('stopped');
@@ -328,7 +389,7 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
 
   return {
     get 'isRunning'() {
-      return server !== undefined || isProxyMode;
+      return httpServer !== undefined || server !== undefined || isProxyMode;
     },
     get 'isConnected'() {
       if (isProxyMode)

--- a/src/executor/server.ts
+++ b/src/executor/server.ts
@@ -72,14 +72,10 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
     }
 
     const httpServerToClose = httpServer;
+    httpServer = undefined;
     isStoppingHttpServer = true;
     httpServerToClose.close(() => {
-      if (httpServer === httpServerToClose) {
-        httpServer = undefined;
-      }
-      if (httpServerToClose.listening === false) {
-        isStoppingHttpServer = false;
-      }
+      isStoppingHttpServer = false;
 
       const restartPort = pendingStartPort;
       pendingStartPort = undefined;

--- a/src/executor/server.ts
+++ b/src/executor/server.ts
@@ -66,7 +66,6 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
 
   const closeHttpServer = (callback?: () => void): void => {
     if (httpServer === undefined) {
-      isStoppingHttpServer = false;
       callback?.();
       return;
     }

--- a/src/executor/server.ts
+++ b/src/executor/server.ts
@@ -23,6 +23,8 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
   let handshakeTimeout: ReturnType<typeof setTimeout> | undefined;
   let proxyWs: WebSocket | undefined;
   let isProxyMode = false;
+  let isStoppingHttpServer = false;
+  let pendingStartPort: number | undefined;
 
   const proxyClients = new Set<WebSocket>();
 
@@ -60,6 +62,33 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
 
   const sendProxyMessage = (message: ProxyStatusChangeMessage | ProxyWelcomeMessage): void => {
     broadcastToProxies(JSON.stringify(message));
+  };
+
+  const closeHttpServer = (callback?: () => void): void => {
+    if (httpServer === undefined) {
+      isStoppingHttpServer = false;
+      callback?.();
+      return;
+    }
+
+    const httpServerToClose = httpServer;
+    isStoppingHttpServer = true;
+    httpServerToClose.close(() => {
+      if (httpServer === httpServerToClose) {
+        httpServer = undefined;
+      }
+      if (httpServerToClose.listening === false) {
+        isStoppingHttpServer = false;
+      }
+
+      const restartPort = pendingStartPort;
+      pendingStartPort = undefined;
+      callback?.();
+
+      if (restartPort !== undefined) {
+        start(restartPort);
+      }
+    });
   };
 
   core.onStatusChange(newStatus => {
@@ -247,6 +276,10 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
   };
 
   const start = (port: number): void => {
+    if (isStoppingHttpServer) {
+      pendingStartPort = port;
+      return;
+    }
     if (httpServer !== undefined || server !== undefined || isProxyMode) return;
 
     setServerTransport();
@@ -337,13 +370,28 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
           startAsProxy(port);
           return;
         }
+        try {
+          server?.close();
+        } catch {
+          /* noop */
+        }
+        server = undefined;
+        closeHttpServer();
         log(`[bridge] HTTP server error: ${err.message}`);
         core.setStatus('error');
       });
       httpServer.listen(port, '127.0.0.1', () => {
+        isStoppingHttpServer = false;
         log(`[bridge] WebSocket server started on port ${port}`);
       });
     } catch (err) {
+      try {
+        server?.close();
+      } catch {
+        /* noop */
+      }
+      server = undefined;
+      closeHttpServer();
       log(`[bridge] Failed to start server: ${err instanceof Error ? err.message : String(err)}`);
       core.setStatus('error');
     }
@@ -377,10 +425,8 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
       server.close();
       server = undefined;
     }
-    if (httpServer !== undefined) {
-      httpServer.close();
-      httpServer = undefined;
-    }
+    pendingStartPort = undefined;
+    closeHttpServer();
     core.setExecutorName(undefined);
     core.setConnected(false);
     core.setStatus('stopped');

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -27,9 +27,24 @@ const waitFor = async (predicate: () => boolean, timeoutMs = 5000): Promise<void
 const getAvailablePort = async (): Promise<number> =>
   await new Promise((resolve, reject) => {
     const server = createHttpServer();
-    server.listen(0, '127.0.0.1', () => {
+    const cleanup = (): void => {
+      server.off('error', onError);
+      server.off('listening', onListening);
+    };
+
+    const onError = (error: Error): void => {
+      cleanup();
+      if (server.listening) {
+        server.close(() => reject(error));
+        return;
+      }
+      reject(error);
+    };
+
+    const onListening = (): void => {
       const address = server.address();
       if (address === null || typeof address === 'string') {
+        cleanup();
         server.close();
         reject(new Error('Failed to resolve ephemeral port'));
         return;
@@ -37,13 +52,18 @@ const getAvailablePort = async (): Promise<number> =>
 
       const port = address.port;
       server.close(error => {
+        cleanup();
         if (error) {
           reject(error);
           return;
         }
         resolve(port);
       });
-    });
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(0, '127.0.0.1');
   });
 
 const getJson = async (port: number, path: string): Promise<{ statusCode: number; body: string }> =>
@@ -362,7 +382,7 @@ describe('ExecutorBridge - Proxy Support', () => {
   test('bridge can restart quickly on the same port', async () => {
     bridge.stop();
     bridge.start(port);
-    await wait(100);
+    await waitFor(() => bridge.isRunning === true);
 
     expect(bridge.isRunning).toBe(true);
   });

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,3 +1,4 @@
+import { createServer as createHttpServer, get as httpGet } from 'node:http';
 import { WebSocket } from 'ws';
 
 import { createBridgeCore } from '@executor/bridgeCore';
@@ -12,6 +13,61 @@ const getPort = (): number => nextPort++;
 const wait = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
 const noop = (): void => {};
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 5000): Promise<void> => {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await wait(25);
+  }
+
+  throw new Error('Condition was not met before timeout');
+};
+
+const getAvailablePort = async (): Promise<number> =>
+  await new Promise((resolve, reject) => {
+    const server = createHttpServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to resolve ephemeral port'));
+        return;
+      }
+
+      const port = address.port;
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+
+const getJson = async (port: number, path: string): Promise<{ statusCode: number; body: string }> =>
+  await new Promise((resolve, reject) => {
+    const req = httpGet(
+      {
+        'host': '127.0.0.1',
+        port,
+        path,
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+        res.on('end', () => {
+          resolve({
+            'statusCode': res.statusCode ?? 0,
+            'body': Buffer.concat(chunks).toString('utf-8'),
+          });
+        });
+      },
+    );
+
+    req.on('error', reject);
+  });
 
 describe('BridgeCore', () => {
   test('initial status is stopped', () => {
@@ -275,6 +331,40 @@ describe('ExecutorBridge - Proxy Support', () => {
   test('bridge starts in waiting state', () => {
     expect(bridge.isRunning).toBe(true);
     expect(bridge.isConnected).toBe(false);
+  });
+
+  test('bridge serves health endpoint on the bridge port', async () => {
+    const healthPort = await getAvailablePort();
+    const healthLogs: string[] = [];
+    const healthBridge = createExecutorBridge(msg => healthLogs.push(msg));
+    healthBridge.start(healthPort);
+
+    try {
+      await waitFor(() => healthLogs.some(log => log.includes(`WebSocket server started on port ${healthPort}`)));
+      const response = await getJson(healthPort, '/health');
+      const payload = JSON.parse(response.body) as {
+        ok: boolean;
+        connected: boolean;
+        executorName?: string;
+        clientType?: string;
+      };
+
+      expect(response.statusCode).toBe(200);
+      expect(payload.ok).toBe(true);
+      expect(payload.connected).toBe(false);
+      expect(payload.executorName).toBeUndefined();
+      expect(payload.clientType).toBeUndefined();
+    } finally {
+      healthBridge.stop();
+    }
+  });
+
+  test('bridge can restart quickly on the same port', async () => {
+    bridge.stop();
+    bridge.start(port);
+    await wait(100);
+
+    expect(bridge.isRunning).toBe(true);
   });
 
   test('bridge accepts executor connection', async () => {


### PR DESCRIPTION
## Summary
- avoid using repeated websocket connects as the primary disconnected-state readiness check
- add a lightweight localhost /health probe on the bridge server and use it from the executor bridge when request APIs are available
- keep reconnect attempts single-flight with backoff so offline bridge polling does not hitch the game client

## Testing
- bun run type-check
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health probe-based gating for connection attempts
  * HTTP health endpoint reporting status, connection state, and client type

* **Bug Fixes & Improvements**
  * Intelligent reconnect scheduling with backoff and debounce
  * Improved graceful restart and shutdown coordination for servers
  * Enhanced error handling and recovery during startup and runtime

* **Tests**
  * Added tests for health endpoint and rapid restart scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->