### PR TITLE
feat: Rojo sourcemap.json support and opt-in game tree auto-refresh

### DIFF
--- a/scripts/executor-bridge.lua
+++ b/scripts/executor-bridge.lua
@@ -1,5 +1,6 @@
 local HttpService = game:GetService'HttpService'
 local Players = game:GetService'Players'
+local RunService = game:GetService'RunService'
 
 local BRIDGE_ID = tostring(math.random(1, 999999999))
 
@@ -716,9 +717,123 @@ local getGameTree = function(services, depth)
 	return tree
 end
 
--- Game tree updates are sent only on connect and when explicitly requested by VS Code.
--- No automatic DescendantAdded/DescendantRemoving listeners — they fire too frequently
--- and flood VS Code with redundant tree dumps. Use the refresh button instead.
+-- Auto-refresh subsystem (opt-in). Event handlers do one flag write; a
+-- RunService.Heartbeat-gated deadline coalesces flushes so bursty edits
+-- (model pastes, respawns, StarterGui loads) don't flood the bridge.
+-- This replaces the previous "no listeners at all" policy — the original
+-- flood concern was the full serialisation per event, not the event
+-- surface itself. Keeping the handlers to a single flag write and
+-- debouncing the flush on Heartbeat makes it safe to opt into.
+--
+-- RBXScriptConnections live inside the top-level `refreshConnections`
+-- table so the bridge's re-execution cleanup (at the top of the file)
+-- disposes them when the script is re-run.
+
+local MIN_AUTO_REFRESH_INTERVAL_SEC = 2.0
+local MAX_COALESCE_SEC = 30.0
+
+local autoRefreshEnabled = false
+local autoRefreshIntervalSec = 5.0
+local autoRefreshDirty = false
+local autoRefreshFirstDirtyAt = nil
+local autoRefreshFlushAt = nil
+local autoRefreshHeartbeat = nil
+local autoRefreshTopLevel = nil
+
+local markAutoRefreshDirty
+local attachAutoRefreshListeners
+local detachAutoRefreshListeners
+local autoRefreshHeartbeatTick
+local setAutoRefresh
+local shutdownAutoRefresh
+
+markAutoRefreshDirty = function()
+	if not autoRefreshEnabled then return end
+	autoRefreshDirty = true
+	local now = os.clock()
+	if autoRefreshFirstDirtyAt == nil then autoRefreshFirstDirtyAt = now end
+	if autoRefreshFlushAt == nil then autoRefreshFlushAt = now + autoRefreshIntervalSec end
+end
+
+attachAutoRefreshListeners = function(instance)
+	if instance == nil then return end
+	local ok, addedConn = pcall(function() return instance.DescendantAdded:Connect(markAutoRefreshDirty) end)
+	if ok and addedConn ~= nil then table.insert(refreshConnections, addedConn) end
+	local ok2, removingConn = pcall(function() return instance.DescendantRemoving:Connect(markAutoRefreshDirty) end)
+	if ok2 and removingConn ~= nil then table.insert(refreshConnections, removingConn) end
+end
+
+detachAutoRefreshListeners = function()
+	for _, conn in ipairs(refreshConnections) do pcall(conn.Disconnect, conn) end
+	-- Clear in-place so the getgenv()._RBXDEV_BRIDGE.refreshConnections
+	-- reference at the top of the file keeps pointing at a valid table.
+	for i = #refreshConnections, 1, -1 do refreshConnections[i] = nil end
+	autoRefreshHeartbeat = nil
+	autoRefreshTopLevel = nil
+end
+
+autoRefreshHeartbeatTick = function()
+	if not autoRefreshEnabled or not autoRefreshDirty then return end
+	local now = os.clock()
+	local force = autoRefreshFirstDirtyAt ~= nil and (now - autoRefreshFirstDirtyAt) >= MAX_COALESCE_SEC
+	if autoRefreshFlushAt ~= nil and now < autoRefreshFlushAt and not force then return end
+
+	-- Clear state BEFORE building: a DescendantAdded firing during
+	-- serialisation must re-arm the next flush, not be lost.
+	autoRefreshDirty = false
+	autoRefreshFirstDirtyAt = nil
+	autoRefreshFlushAt = nil
+
+	if not connected then return end
+	local ok, tree = pcall(getGameTree, nil, CONFIG.updateTreeDepth)
+	if ok and connected then
+		pcall(send, { type = 'gameTree', data = tree })
+	end
+end
+
+setAutoRefresh = function(enabled, intervalMs)
+	local newEnabled = enabled == true
+	local rawInterval = tonumber(intervalMs) or 5000
+	local newIntervalSec = math.max(MIN_AUTO_REFRESH_INTERVAL_SEC, rawInterval / 1000)
+
+	if newEnabled == autoRefreshEnabled and newIntervalSec == autoRefreshIntervalSec and newEnabled then
+		return
+	end
+
+	detachAutoRefreshListeners()
+	autoRefreshDirty = false
+	autoRefreshFirstDirtyAt = nil
+	autoRefreshFlushAt = nil
+
+	autoRefreshEnabled = newEnabled
+	autoRefreshIntervalSec = newIntervalSec
+
+	if not autoRefreshEnabled then return end
+
+	for _, serviceName in ipairs(CONFIG.gameTreeServices) do
+		local ok, svc = pcall(game.GetService, game, serviceName)
+		if ok and svc ~= nil then attachAutoRefreshListeners(svc) end
+	end
+
+	-- Cover top-level children not in the standard allowlist: when a new
+	-- top-level service/child appears, attach listeners and mark dirty.
+	autoRefreshTopLevel = game.ChildAdded:Connect(function(child)
+		attachAutoRefreshListeners(child)
+		markAutoRefreshDirty()
+	end)
+	if autoRefreshTopLevel ~= nil then table.insert(refreshConnections, autoRefreshTopLevel) end
+
+	autoRefreshHeartbeat = RunService.Heartbeat:Connect(autoRefreshHeartbeatTick)
+	if autoRefreshHeartbeat ~= nil then table.insert(refreshConnections, autoRefreshHeartbeat) end
+end
+
+shutdownAutoRefresh = function()
+	detachAutoRefreshListeners()
+	autoRefreshEnabled = false
+	autoRefreshDirty = false
+	autoRefreshFirstDirtyAt = nil
+	autoRefreshFlushAt = nil
+end
 
 --  Teleport helper
 
@@ -792,6 +907,10 @@ end
 MESSAGE_HANDLERS.requestGameTree = function(message)
 	local depth = message.depth or CONFIG.updateTreeDepth
 	send{ type = 'gameTree', data = getGameTree(message.services, depth) }
+end
+
+MESSAGE_HANDLERS.setAutoRefresh = function(message)
+	setAutoRefresh(message.enabled, message.intervalMs)
 end
 
 MESSAGE_HANDLERS.requestChildren = function(message)
@@ -1260,6 +1379,7 @@ connect = function(scheduleOnFailure)
 	ws.OnClose:Connect(function()
 		connected = false
 		connection = nil
+		shutdownAutoRefresh()
 		scheduleReconnect()
 	end)
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as url from 'url';
 
 import { createExecutorBridge } from '@executor';
@@ -102,6 +103,34 @@ export const startServer = (state: ServerState): void => {
     return createInitializeResult(params);
   });
 
+  let sourcemapWatcher: fs.FSWatcher | undefined;
+  let sourcemapReloadTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const setupSourcemapWatcher = (sourcemapPath: string): void => {
+    try {
+      sourcemapWatcher = fs.watch(sourcemapPath, eventType => {
+        if (eventType !== 'change' && eventType !== 'rename') return;
+        if (sourcemapReloadTimer !== undefined) clearTimeout(sourcemapReloadTimer);
+        sourcemapReloadTimer = setTimeout(() => {
+          sourcemapReloadTimer = undefined;
+          connection.console.log(`Reloading workspace from sourcemap: ${sourcemapPath}`);
+          documentManager.reloadWorkspace();
+          const moduleIndex = documentManager.getModuleIndex();
+          connection.console.log(`Reindexed ${moduleIndex.size} modules from sourcemap`);
+          // Best-effort: clients without pull-diagnostics support will reject this harmlessly.
+          void connection.sendRequest('workspace/diagnostic/refresh').catch(() => {
+            /* noop */
+          });
+        }, 500);
+      });
+      sourcemapWatcher.on('error', err => {
+        connection.console.log(`Sourcemap watcher error: ${err.message}`);
+      });
+    } catch (err) {
+      connection.console.log(`Failed to watch sourcemap.json: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
   connection.onInitialized(() => {
     connection.console.log('rbxdev-ls initialized successfully');
 
@@ -110,7 +139,14 @@ export const startServer = (state: ServerState): void => {
       documentManager.initializeWorkspace(workspacePath);
 
       const rojoState = documentManager.getRojoState();
-      if (rojoState?.project !== undefined) connection.console.log(`Found Rojo project: ${rojoState.project.name}`);
+      if (rojoState?.project !== undefined) {
+        connection.console.log(`Workspace tree source: Rojo project (${rojoState.project.name})`);
+      } else if (rojoState?.projectPath !== undefined && rojoState.projectPath.endsWith('sourcemap.json')) {
+        connection.console.log(`Workspace tree source: sourcemap.json (${rojoState.projectPath})`);
+        setupSourcemapWatcher(rojoState.projectPath);
+      } else {
+        connection.console.log('Workspace tree source: fallback directory scan');
+      }
 
       const moduleIndex = documentManager.getModuleIndex();
       connection.console.log(`Indexed ${moduleIndex.size} modules`);
@@ -121,6 +157,18 @@ export const startServer = (state: ServerState): void => {
 
   connection.onShutdown(() => {
     connection.console.log('rbxdev-ls shutting down...');
+    if (sourcemapReloadTimer !== undefined) {
+      clearTimeout(sourcemapReloadTimer);
+      sourcemapReloadTimer = undefined;
+    }
+    if (sourcemapWatcher !== undefined) {
+      try {
+        sourcemapWatcher.close();
+      } catch {
+        /* noop */
+      }
+      sourcemapWatcher = undefined;
+    }
     executorBridge.stop();
   });
 
@@ -147,6 +195,12 @@ export const startServer = (state: ServerState): void => {
 
   connection.onRequest('custom/requestGameTree', () => {
     executorBridge.requestGameTree();
+    return { 'success': true };
+  });
+
+  connection.onRequest('custom/setAutoRefresh', (params: { enabled: boolean; intervalMs: number }) => {
+    const intervalMs = Math.max(2000, Math.floor(params.intervalMs));
+    executorBridge.setAutoRefresh(params.enabled === true, intervalMs);
     return { 'success': true };
   });
 

--- a/src/executor/bridgeCore.ts
+++ b/src/executor/bridgeCore.ts
@@ -54,6 +54,7 @@ export interface BridgeCore {
   readonly rejectAllPending: (reason: string) => void;
   readonly execute: (code: string) => Promise<ExecuteResult>;
   readonly requestGameTree: () => void;
+  readonly setAutoRefresh: (enabled: boolean, intervalMs: number) => void;
   readonly requestProperties: (
     path: ReadonlyArray<string>,
     properties?: ReadonlyArray<string>,
@@ -366,6 +367,10 @@ export const createBridgeCore = (
     sendFn({ 'type': 'requestGameTree' });
   };
 
+  const setAutoRefresh = (enabled: boolean, intervalMs: number): void => {
+    sendFn({ 'type': 'setAutoRefresh', enabled, intervalMs });
+  };
+
   const requestProperties = (
     path: ReadonlyArray<string>,
     properties?: ReadonlyArray<string>,
@@ -517,6 +522,7 @@ export const createBridgeCore = (
     rejectAllPending,
     execute,
     requestGameTree,
+    setAutoRefresh,
     requestProperties,
     requestModuleInterface,
     setProperty,

--- a/src/executor/proxy.ts
+++ b/src/executor/proxy.ts
@@ -164,6 +164,7 @@ export const createProxyBridge = (log: (message: string) => void): ExecutorBridg
     stop,
     'execute': core.execute,
     'requestGameTree': core.requestGameTree,
+    'setAutoRefresh': core.setAutoRefresh,
     'requestProperties': core.requestProperties,
     'requestModuleInterface': core.requestModuleInterface,
     'setProperty': core.setProperty,

--- a/src/executor/server.ts
+++ b/src/executor/server.ts
@@ -455,6 +455,7 @@ export const createExecutorBridge = (log: (message: string) => void): ExecutorBr
     stop,
     'execute': core.execute,
     'requestGameTree': core.requestGameTree,
+    'setAutoRefresh': core.setAutoRefresh,
     'requestProperties': core.requestProperties,
     'requestModuleInterface': core.requestModuleInterface,
     'setProperty': core.setProperty,

--- a/src/lsp/documents.ts
+++ b/src/lsp/documents.ts
@@ -6,6 +6,7 @@ import type { LuauType, PropertyType } from '@typings/types';
 import { AnyType, createFunctionType, createTableType } from '@typings/types';
 import { buildModuleIndex, searchExports } from '@workspace/moduleIndex';
 import { loadRojoState } from '@workspace/rojo';
+import { loadSourcemapState } from '@workspace/sourcemap';
 
 import type { Comment } from '@typings/ast';
 import type { DocumentManager, ParsedDocument } from '@typings/lsp';
@@ -103,8 +104,19 @@ export const createDocumentManager = (): DocumentManager => {
             const properties = new Map<string, PropertyType>();
             for (const exp of info.exports) {
               let propType: LuauType = AnyType;
-              if (exp.kind === 'function') propType = createFunctionType([], AnyType);
-              else if (exp.kind === 'table') propType = createTableType(new Map());
+              if (exp.kind === 'function') {
+                if (exp.signature !== undefined) {
+                  propType = createFunctionType(
+                    exp.signature.params.map(p => ({ 'name': p.name, 'type': p.type, 'optional': p.optional })),
+                    exp.signature.returnType,
+                    { 'isVariadic': exp.signature.isVariadic },
+                  );
+                } else {
+                  propType = createFunctionType([], AnyType);
+                }
+              } else if (exp.kind === 'table') {
+                propType = createTableType(new Map());
+              }
               properties.set(exp.name, { 'type': propType, 'readonly': true, 'optional': false });
             }
             return createTableType(properties);
@@ -157,10 +169,17 @@ export const createDocumentManager = (): DocumentManager => {
 
   let rojoState: RojoState | undefined;
   let moduleIndex: Map<string, ModuleInfo> = new Map();
+  let currentWorkspacePath: string | undefined;
 
   const initializeWorkspace = (workspacePath: string): void => {
-    rojoState = loadRojoState(workspacePath);
+    currentWorkspacePath = workspacePath;
+    const sourcemapState = loadSourcemapState(workspacePath);
+    rojoState = sourcemapState.dataModel !== undefined ? sourcemapState : loadRojoState(workspacePath);
     moduleIndex = buildModuleIndex(rojoState, workspacePath);
+  };
+
+  const reloadWorkspace = (): void => {
+    if (currentWorkspacePath !== undefined) initializeWorkspace(currentWorkspacePath);
   };
 
   const getRojoState = (): RojoState | undefined => rojoState;
@@ -176,6 +195,7 @@ export const createDocumentManager = (): DocumentManager => {
     getDocument,
     removeDocument,
     initializeWorkspace,
+    reloadWorkspace,
     getRojoState,
     getModuleIndex,
     searchModuleExports,

--- a/src/lsp/handlers/hover.ts
+++ b/src/lsp/handlers/hover.ts
@@ -6,7 +6,7 @@ import { typeToString } from '@typings/types';
 import { MarkupKind } from 'vscode-languageserver';
 
 import type { DeprecationInfo, MemberAccessInfo } from '@typings/handlers';
-import type { DocumentManager } from '@typings/lsp';
+import type { DocumentManager, ParsedDocument } from '@typings/lsp';
 import type { Scope } from '@typings/environment';
 import type { ClassMethod, ClassProperty, ClassType, FunctionType, LuauType, TableType } from '@typings/types';
 import type { Connection, Hover, HoverParams } from 'vscode-languageserver';
@@ -342,6 +342,63 @@ const extractGamePath = (content: string, line: number, character: number): Read
   return undefined;
 };
 
+/**
+ * Walks a document's local scopes and file-level scope for a symbol named
+ * `name` and returns its type if found. Used by the hover handler to find
+ * user-defined locals like module-bound tables and typed variables.
+ */
+export const resolveSymbolTypeInDocument = (document: ParsedDocument, name: string): LuauType | undefined => {
+  if (document.typeCheckResult === undefined) return undefined;
+  const env = document.typeCheckResult.environment;
+
+  let walkScope: Scope | undefined = env.currentScope;
+  while (walkScope !== undefined) {
+    const localSymbol = walkScope.symbols.get(name);
+    if (localSymbol !== undefined) return localSymbol.type;
+    walkScope = walkScope.parent;
+  }
+
+  const fileSymbol = env.globalScope.symbols.get(name);
+  return fileSymbol?.type;
+};
+
+/**
+ * Formats a member access hover for an already-resolved object type.
+ * Supports user tables (module exports via require resolver) and typed
+ * locals that carry a Class type. Returns the markdown body (without
+ * Roblox "Live Value" suffixes) or undefined if the member isn't found.
+ */
+export const formatMemberHoverForType = (
+  objectType: LuauType,
+  memberName: string,
+  resolveClass: (className: string) => ClassType | undefined,
+): string | undefined => {
+  if (objectType.kind === 'Table') {
+    const memberProp = objectType.properties.get(memberName);
+    if (memberProp === undefined) return undefined;
+    return formatTypeDocFull(memberName, memberProp.type);
+  }
+
+  if (objectType.kind === 'Class') {
+    const getSuperclassName = (className: string): string | undefined => {
+      const cls = resolveClass(className);
+      if (cls !== undefined && cls.kind === 'Class' && cls.superclass !== undefined) return cls.superclass.name;
+      return undefined;
+    };
+    const member = lookupClassMember(objectType, memberName, getSuperclassName);
+    if (member === undefined) return undefined;
+    if (member.kind === 'method') {
+      return '```lua\n' + formatMethodDoc(memberName, member.method) + '\n```';
+    }
+    if (member.kind === 'property') {
+      return '```lua\n' + formatPropertyDoc(memberName, member.prop) + '\n```';
+    }
+    return undefined;
+  }
+
+  return undefined;
+};
+
 /** Registers the hover handler with the LSP connection. */
 export const setupHoverHandler = (
   connection: Connection,
@@ -451,6 +508,27 @@ export const setupHoverHandler = (
             'contents': {
               'kind': MarkupKind.Markdown,
               'value': formatTypeDocFull(memberAccess.memberName, memberProp.type) + liveValueMarkdown,
+            },
+          };
+        }
+      }
+
+      // Walk the document's local + file-level scopes for the object name.
+      // This covers user-defined table locals (including module exports
+      // surfaced by the require resolver through sourcemap.json / Rojo)
+      // as well as class-typed locals like `local part: BasePart`.
+      const localObjectType = resolveSymbolTypeInDocument(document, memberAccess.objectName);
+      if (localObjectType !== undefined) {
+        const resolveClass = (className: string): ClassType | undefined => {
+          const cls = documentManager.globalEnv.robloxClasses.get(className);
+          return cls !== undefined && cls.kind === 'Class' ? cls : undefined;
+        };
+        const markdown = formatMemberHoverForType(localObjectType, memberAccess.memberName, resolveClass);
+        if (markdown !== undefined) {
+          return {
+            'contents': {
+              'kind': MarkupKind.Markdown,
+              'value': markdown + liveValueMarkdown,
             },
           };
         }

--- a/src/typings/bridge.ts
+++ b/src/typings/bridge.ts
@@ -81,6 +81,7 @@ export interface ExecutorBridge {
   stop: () => void;
   execute: (code: string) => Promise<ExecuteResult>;
   requestGameTree: () => void;
+  setAutoRefresh: (enabled: boolean, intervalMs: number) => void;
   requestProperties: (path: ReadonlyArray<string>, properties?: ReadonlyArray<string>) => Promise<PropertiesResult>;
   requestModuleInterface: (moduleRef: ModuleReference) => Promise<ModuleInterfaceResult>;
   setProperty: (

--- a/src/typings/lsp.ts
+++ b/src/typings/lsp.ts
@@ -24,6 +24,7 @@ export interface DocumentManager {
   getDocument: (uri: string) => ParsedDocument | undefined;
   removeDocument: (uri: string) => void;
   initializeWorkspace: (workspacePath: string) => void;
+  reloadWorkspace: () => void;
   getRojoState: () => RojoState | undefined;
   getModuleIndex: () => Map<string, ModuleInfo>;
   searchModuleExports: (query: string) => ModuleExport[];

--- a/src/typings/protocol.ts
+++ b/src/typings/protocol.ts
@@ -23,6 +23,12 @@ export interface RequestGameTreeMessage {
   readonly services?: string[];
 }
 
+export interface SetAutoRefreshMessage {
+  readonly type: 'setAutoRefresh';
+  readonly enabled: boolean;
+  readonly intervalMs: number;
+}
+
 export interface RequestPropertiesMessage {
   readonly type: 'requestProperties';
   readonly id: string;
@@ -127,6 +133,7 @@ export interface SetScriptSourceMessage {
 export type ServerMessage =
   | ExecuteMessage
   | RequestGameTreeMessage
+  | SetAutoRefreshMessage
   | RequestPropertiesMessage
   | RequestModuleInterfaceMessage
   | SetPropertyMessage

--- a/src/typings/workspace.ts
+++ b/src/typings/workspace.ts
@@ -26,11 +26,24 @@ export interface RojoState {
   readonly projectPath: string | undefined;
 }
 
+export interface ModuleExportSignatureParam {
+  readonly name: string | undefined;
+  readonly type: import('./types').LuauType;
+  readonly optional: boolean;
+}
+
+export interface ModuleExportSignature {
+  readonly params: ReadonlyArray<ModuleExportSignatureParam>;
+  readonly returnType: import('./types').LuauType;
+  readonly isVariadic: boolean;
+}
+
 export interface ModuleExport {
   readonly name: string;
   readonly kind: 'function' | 'table' | 'value' | 'type';
   readonly modulePath: string;
   readonly filePath: string;
+  readonly signature?: ModuleExportSignature;
 }
 
 export interface ModuleInfo {

--- a/src/workspace/annotationResolver.ts
+++ b/src/workspace/annotationResolver.ts
@@ -1,0 +1,86 @@
+import {
+  AnyType,
+  BooleanType,
+  BufferType,
+  createUnionType,
+  NilType,
+  NumberType,
+  StringType,
+  ThreadType,
+  UnknownType,
+  VectorType,
+} from '@typings/types';
+
+import type { TypeAnnotation } from '@typings/ast';
+import type { LuauType, PrimitiveType } from '@typings/types';
+
+/**
+ * Resolves a subset of Luau type annotations to `LuauType` without needing
+ * a full checker state. Handles primitives, optional, and flat unions —
+ * the cases that show up in the function signatures of typical module
+ * exports. Anything more exotic (generics, class references, user-defined
+ * type aliases, table types, nested function types, etc.) falls back to
+ * `AnyType` so downstream consumers still get a usable `FunctionType`
+ * even when the detailed shape isn't available.
+ *
+ * This is a deliberately lossy converter intended for the workspace
+ * module index, where we cannot run the full checker on every required
+ * module. For full-fidelity resolution, the type checker's own
+ * `resolveTypeAnnotation` is authoritative.
+ */
+export const resolveAnnotationToType = (annotation: TypeAnnotation | undefined): LuauType => {
+  if (annotation === undefined) return AnyType;
+
+  switch (annotation.kind) {
+    case 'TypeReference': {
+      const primitive = resolvePrimitiveByName(annotation.name);
+      if (primitive !== undefined) return primitive;
+      if (annotation.name === 'any') return AnyType;
+      if (annotation.name === 'unknown') return UnknownType;
+      // Class references, user type aliases, generics → unresolved here.
+      // Fall back to any so the enclosing function type still works.
+      return AnyType;
+    }
+
+    case 'OptionalType':
+      return createUnionType([resolveAnnotationToType(annotation.type), NilType]);
+
+    case 'UnionType':
+      return createUnionType(annotation.types.map(t => resolveAnnotationToType(t)));
+
+    case 'ParenthesizedType':
+      return resolveAnnotationToType(annotation.type);
+
+    case 'TypeLiteral':
+      // String/number/boolean literal types reduce to their base primitive
+      // for our purposes. We don't model literal types in the module index.
+      if (typeof annotation.value === 'string') return StringType;
+      if (typeof annotation.value === 'number') return NumberType;
+      if (typeof annotation.value === 'boolean') return BooleanType;
+      return AnyType;
+
+    default:
+      return AnyType;
+  }
+};
+
+const resolvePrimitiveByName = (name: string): PrimitiveType | undefined => {
+  switch (name) {
+    case 'nil':
+      return NilType;
+    case 'boolean':
+      return BooleanType;
+    case 'number':
+      return NumberType;
+    case 'string':
+      return StringType;
+    case 'thread':
+      return ThreadType;
+    case 'buffer':
+      return BufferType;
+    case 'vector':
+      return VectorType;
+    default:
+      return undefined;
+  }
+};

--- a/src/workspace/moduleIndex.ts
+++ b/src/workspace/moduleIndex.ts
@@ -3,8 +3,35 @@ import * as path from 'path';
 
 import { parse } from '@parser/parser';
 
-import type { Chunk } from '@typings/ast';
-import type { DataModelNode, ModuleExport, ModuleFileEntry, ModuleInfo, RojoState } from '@typings/workspace';
+import type { Chunk, FunctionExpression } from '@typings/ast';
+import type {
+  DataModelNode,
+  ModuleExport,
+  ModuleExportSignature,
+  ModuleExportSignatureParam,
+  ModuleFileEntry,
+  ModuleInfo,
+  RojoState,
+} from '@typings/workspace';
+
+import { resolveAnnotationToType } from './annotationResolver';
+
+const buildSignature = (func: FunctionExpression): ModuleExportSignature => {
+  const params: ModuleExportSignatureParam[] = [];
+  for (const param of func.params) {
+    if (param.name === undefined) continue;
+    params.push({
+      'name': param.name.name,
+      'type': resolveAnnotationToType(param.type),
+      'optional': false,
+    });
+  }
+  return {
+    params,
+    'returnType': resolveAnnotationToType(func.returnType),
+    'isVariadic': func.isVariadic,
+  };
+};
 
 const extractModuleExports = (chunk: Chunk, filePath: string, dataModelPath: string[]): ModuleExport[] => {
   const exports: ModuleExport[] = [];
@@ -24,14 +51,16 @@ const extractModuleExports = (chunk: Chunk, filePath: string, dataModelPath: str
       if (field.kind === 'TableFieldKey') {
         const name = field.key.name;
         let kind: ModuleExport['kind'] = 'value';
+        let signature: ModuleExportSignature | undefined;
 
         if (field.value.kind === 'FunctionExpression') {
           kind = 'function';
+          signature = buildSignature(field.value);
         } else if (field.value.kind === 'TableExpression') {
           kind = 'table';
         }
 
-        exports.push({ name, kind, modulePath, filePath });
+        exports.push({ name, kind, modulePath, filePath, ...(signature !== undefined ? { signature } : {}) });
       }
     }
     return exports;
@@ -50,14 +79,22 @@ const extractModuleExports = (chunk: Chunk, filePath: string, dataModelPath: str
               if (field.kind === 'TableFieldKey') {
                 const name = field.key.name;
                 let kind: ModuleExport['kind'] = 'value';
+                let signature: ModuleExportSignature | undefined;
 
                 if (field.value.kind === 'FunctionExpression') {
                   kind = 'function';
+                  signature = buildSignature(field.value);
                 } else if (field.value.kind === 'TableExpression') {
                   kind = 'table';
                 }
 
-                exports.push({ name, kind, modulePath, filePath });
+                exports.push({
+                  name,
+                  kind,
+                  modulePath,
+                  filePath,
+                  ...(signature !== undefined ? { signature } : {}),
+                });
               }
             }
           }
@@ -77,21 +114,29 @@ const extractModuleExports = (chunk: Chunk, filePath: string, dataModelPath: str
           const name = target.property.name;
           const value = stmt.values[0];
           let kind: ModuleExport['kind'] = 'value';
+          let signature: ModuleExportSignature | undefined;
 
           if (value?.kind === 'FunctionExpression') {
             kind = 'function';
+            signature = buildSignature(value);
           } else if (value?.kind === 'TableExpression') {
             kind = 'table';
           }
 
-          exports.push({ name, kind, modulePath, filePath });
+          exports.push({ name, kind, modulePath, filePath, ...(signature !== undefined ? { signature } : {}) });
         }
       }
 
       if (stmt.kind === 'FunctionDeclaration' && stmt.name.base.name === varName) {
         const funcName = stmt.name.method?.name ?? stmt.name.path[stmt.name.path.length - 1]?.name;
         if (funcName !== undefined) {
-          exports.push({ 'name': funcName, 'kind': 'function', modulePath, filePath });
+          exports.push({
+            'name': funcName,
+            'kind': 'function',
+            modulePath,
+            filePath,
+            'signature': buildSignature(stmt.func),
+          });
         }
       }
     }

--- a/src/workspace/sourcemap.ts
+++ b/src/workspace/sourcemap.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { DataModelNode, RojoState } from '@typings/workspace';
+
+/**
+ * Node shape of a Rojo-style `sourcemap.json` file, as produced by
+ * `rojo sourcemap --output sourcemap.json [--include-non-scripts]`.
+ *
+ * Mirrors the on-disk schema exactly — do not add speculative fields.
+ * `filePaths` and `children` are omitted by Rojo when empty, so consumers
+ * must default both to `[]`.
+ */
+export interface SourcemapNode {
+  readonly name: string;
+  readonly className: string;
+  readonly filePaths?: ReadonlyArray<string>;
+  readonly children?: ReadonlyArray<SourcemapNode>;
+}
+
+/** Searches for a `sourcemap.json` file at the workspace root. */
+export const findSourcemap = (workspacePath: string): string | undefined => {
+  const sourcemapPath = path.join(workspacePath, 'sourcemap.json');
+  if (fs.existsSync(sourcemapPath)) return sourcemapPath;
+  return undefined;
+};
+
+const isValidNode = (value: unknown): value is SourcemapNode => {
+  if (typeof value !== 'object' || value === null) return false;
+  const node = value as { name?: unknown; className?: unknown };
+  return typeof node.name === 'string' && typeof node.className === 'string';
+};
+
+/** Parses a sourcemap.json file and validates its top-level structure. */
+export const parseSourcemap = (filePath: string): SourcemapNode | undefined => {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content);
+    if (isValidNode(parsed) === false) return undefined;
+    return parsed;
+  } catch {
+    return undefined;
+  }
+};
+
+const LUA_EXT_RE = /\.(lua|luau)$/;
+
+/**
+ * Picks the best filesystem path from a sourcemap node's `filePaths` list.
+ *
+ * A folder-backed ModuleScript emits multiple entries — e.g.
+ * `["Foo", "Foo/init.lua"]` — and we prefer the actual `.lua`/`.luau` file
+ * over the directory path so downstream consumers (moduleIndex) hit the
+ * file-read branch instead of scanning the directory.
+ */
+const chooseFilePath = (filePaths: ReadonlyArray<string> | undefined, baseDir: string): string | undefined => {
+  if (filePaths === undefined || filePaths.length === 0) return undefined;
+
+  const resolved = filePaths.map(p => path.normalize(path.isAbsolute(p) ? p : path.join(baseDir, p)));
+
+  const script = resolved.find(p => LUA_EXT_RE.test(p));
+  if (script !== undefined) return script;
+
+  return resolved[0];
+};
+
+/**
+ * Converts a parsed sourcemap tree into the `DataModelNode` structure the
+ * rest of the language server consumes. Paths in `filePaths` are resolved
+ * relative to `baseDir` (the directory containing the sourcemap file,
+ * which by convention is also the project-file directory).
+ */
+export const buildDataModelTreeFromSourcemap = (root: SourcemapNode, baseDir: string): DataModelNode => {
+  const buildNode = (sourcemap: SourcemapNode): DataModelNode => {
+    const filePath = chooseFilePath(sourcemap.filePaths, baseDir);
+    const children = new Map<string, DataModelNode>();
+
+    const sourcemapChildren = sourcemap.children ?? [];
+    for (const child of sourcemapChildren) {
+      if (isValidNode(child) === false) continue;
+      // Rojo does not dedupe duplicate child names; keep the first (matches
+      // Instance:FindFirstChild semantics).
+      if (children.has(child.name)) continue;
+      children.set(child.name, buildNode(child));
+    }
+
+    return {
+      'name': sourcemap.name,
+      'className': sourcemap.className,
+      ...(filePath !== undefined ? { filePath } : {}),
+      children,
+    };
+  };
+
+  return buildNode(root);
+};
+
+/**
+ * Loads the workspace tree from a `sourcemap.json` at the workspace root,
+ * if one exists. Returns a `RojoState`-shaped object so the caller can
+ * drop it into the same downstream consumers as Rojo state without any
+ * type gymnastics. `project` is always undefined for sourcemap-backed
+ * workspaces — the sourcemap file is the description, not a project.
+ */
+export const loadSourcemapState = (workspacePath: string): RojoState => {
+  const sourcemapPath = findSourcemap(workspacePath);
+  if (sourcemapPath === undefined) {
+    return { 'project': undefined, 'dataModel': undefined, 'projectPath': undefined };
+  }
+
+  const root = parseSourcemap(sourcemapPath);
+  if (root === undefined) {
+    return { 'project': undefined, 'dataModel': undefined, 'projectPath': sourcemapPath };
+  }
+
+  const baseDir = path.dirname(sourcemapPath);
+  const dataModel = buildDataModelTreeFromSourcemap(root, baseDir);
+
+  return { 'project': undefined, dataModel, 'projectPath': sourcemapPath };
+};

--- a/studio-plugin/src/handlers/gameTree.luau
+++ b/studio-plugin/src/handlers/gameTree.luau
@@ -1,3 +1,5 @@
+local RunService = game:GetService'RunService'
+
 local protocol = require(script.Parent.Parent.protocol)
 
 local gameTree = {}
@@ -12,6 +14,22 @@ local CONFIG = {
 		'SoundService', 'Chat', 'Teams',
 	},
 }
+
+-- Auto-refresh subsystem (opt-in). Event handlers do one flag write; a
+-- RunService.Heartbeat-gated deadline coalesces flushes so bursty edits
+-- (model pastes, respawns, StarterGui loads) don't flood the bridge.
+local MIN_INTERVAL_SEC = 2.0
+local MAX_COALESCE_SEC = 30.0
+
+local autoRefreshEnabled = false
+local autoRefreshIntervalSec = 5.0
+local isDirty = false
+local firstDirtyAt = nil
+local flushAt = nil
+local serviceConnections = {}
+local topLevelConnection = nil
+local heartbeatConnection = nil
+local onFlushCallback = nil
 
 local serializeInstance
 serializeInstance = function(instance, depth)
@@ -81,6 +99,97 @@ gameTree.getChildren = function(path)
 		if childNode ~= nil then table.insert(result, childNode) end
 	end
 	return { success = true, children = result }
+end
+
+local markDirty = function()
+	if not autoRefreshEnabled then return end
+	isDirty = true
+	local now = os.clock()
+	if firstDirtyAt == nil then firstDirtyAt = now end
+	if flushAt == nil then flushAt = now + autoRefreshIntervalSec end
+end
+
+local attachServiceListeners = function(instance)
+	if instance == nil then return end
+	local ok, addedConn = pcall(function() return instance.DescendantAdded:Connect(markDirty) end)
+	if ok and addedConn ~= nil then table.insert(serviceConnections, addedConn) end
+	local ok2, removingConn = pcall(function() return instance.DescendantRemoving:Connect(markDirty) end)
+	if ok2 and removingConn ~= nil then table.insert(serviceConnections, removingConn) end
+end
+
+local detachAllListeners = function()
+	for _, conn in ipairs(serviceConnections) do pcall(conn.Disconnect, conn) end
+	serviceConnections = {}
+	if topLevelConnection ~= nil then
+		pcall(topLevelConnection.Disconnect, topLevelConnection)
+		topLevelConnection = nil
+	end
+	if heartbeatConnection ~= nil then
+		pcall(heartbeatConnection.Disconnect, heartbeatConnection)
+		heartbeatConnection = nil
+	end
+end
+
+local heartbeatTick = function()
+	if not autoRefreshEnabled or not isDirty then return end
+	local now = os.clock()
+	local force = firstDirtyAt ~= nil and (now - firstDirtyAt) >= MAX_COALESCE_SEC
+	if flushAt ~= nil and now < flushAt and not force then return end
+
+	-- Clear state BEFORE building: a DescendantAdded firing during
+	-- serialisation must re-arm the next flush, not be lost.
+	isDirty = false
+	firstDirtyAt = nil
+	flushAt = nil
+
+	local ok, tree = pcall(gameTree.buildTree, nil)
+	if ok and onFlushCallback ~= nil then
+		pcall(onFlushCallback, tree)
+	end
+end
+
+gameTree.setAutoRefresh = function(enabled, intervalMs, flushCallback)
+	local newEnabled = enabled == true
+	local rawInterval = tonumber(intervalMs) or 5000
+	local newIntervalSec = math.max(MIN_INTERVAL_SEC, rawInterval / 1000)
+
+	onFlushCallback = flushCallback
+
+	if newEnabled == autoRefreshEnabled and newIntervalSec == autoRefreshIntervalSec and newEnabled then
+		return
+	end
+
+	detachAllListeners()
+	isDirty = false
+	firstDirtyAt = nil
+	flushAt = nil
+
+	autoRefreshEnabled = newEnabled
+	autoRefreshIntervalSec = newIntervalSec
+
+	if not autoRefreshEnabled then return end
+
+	for _, serviceName in ipairs(CONFIG.gameTreeServices) do
+		local ok, svc = pcall(game.GetService, game, serviceName)
+		if ok and svc ~= nil then attachServiceListeners(svc) end
+	end
+
+	-- Also cover top-level children that are not in the standard allowlist.
+	topLevelConnection = game.ChildAdded:Connect(function(child)
+		attachServiceListeners(child)
+		markDirty()
+	end)
+
+	heartbeatConnection = RunService.Heartbeat:Connect(heartbeatTick)
+end
+
+gameTree.shutdownAutoRefresh = function()
+	detachAllListeners()
+	autoRefreshEnabled = false
+	isDirty = false
+	firstDirtyAt = nil
+	flushAt = nil
+	onFlushCallback = nil
 end
 
 return gameTree

--- a/studio-plugin/src/init.server.luau
+++ b/studio-plugin/src/init.server.luau
@@ -51,6 +51,12 @@ MESSAGE_HANDLERS.requestGameTree = function(message)
 	sendMessage{ type = 'gameTree', data = gameTreeHandler.buildTree(message.services) }
 end
 
+MESSAGE_HANDLERS.setAutoRefresh = function(message)
+	gameTreeHandler.setAutoRefresh(message.enabled, message.intervalMs, function(tree)
+		sendMessage{ type = 'gameTree', data = tree }
+	end)
+end
+
 MESSAGE_HANDLERS.requestChildren = function(message)
 	local result = gameTreeHandler.getChildren(message.path)
 	sendResult('childrenResult', message.id, result.success, {
@@ -239,14 +245,23 @@ connect = function()
 
 	wsClient.Closed:Connect(function()
 		warn'[rbxdev-studio] Disconnected from bridge, reconnecting...'
+		gameTreeHandler.shutdownAutoRefresh()
 		scheduleReconnect()
 	end)
 
 	wsClient.Error:Connect(function(statusCode, errorMessage)
 		warn('[rbxdev-studio] WebSocket error:', statusCode, errorMessage)
+		gameTreeHandler.shutdownAutoRefresh()
 		scheduleReconnect()
 	end)
 end
 
 consoleHandler.setup(sendMessage)
+
+if plugin ~= nil then
+	plugin.Unloading:Connect(function()
+		gameTreeHandler.shutdownAutoRefresh()
+	end)
+end
+
 connect()

--- a/tests/auto-refresh.test.ts
+++ b/tests/auto-refresh.test.ts
@@ -1,0 +1,199 @@
+import { readFileSync } from 'fs';
+import * as path from 'path';
+
+import { describe, expect, test } from 'bun:test';
+
+import { createBridgeCore } from '@executor/bridgeCore';
+import type { ServerMessage } from '@typings/protocol';
+
+const noop = (): void => {};
+
+describe('BridgeCore.setAutoRefresh', () => {
+  test('sends a setAutoRefresh message with the given enabled + intervalMs', () => {
+    const sent: ServerMessage[] = [];
+    const core = createBridgeCore(m => sent.push(m), () => true, noop);
+
+    core.setAutoRefresh(true, 5000);
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0]!;
+    expect(msg.type).toBe('setAutoRefresh');
+    if (msg.type === 'setAutoRefresh') {
+      expect(msg.enabled).toBe(true);
+      expect(msg.intervalMs).toBe(5000);
+    }
+  });
+
+  test('forwards disabled state', () => {
+    const sent: ServerMessage[] = [];
+    const core = createBridgeCore(m => sent.push(m), () => true, noop);
+
+    core.setAutoRefresh(false, 2000);
+
+    expect(sent).toHaveLength(1);
+    const msg = sent[0]!;
+    if (msg.type === 'setAutoRefresh') {
+      expect(msg.enabled).toBe(false);
+      expect(msg.intervalMs).toBe(2000);
+    } else {
+      throw new Error('expected setAutoRefresh message');
+    }
+  });
+
+  test('does not require a connected executor (fire-and-forget)', () => {
+    // Unlike createRequest-based methods, setAutoRefresh is fire-and-forget:
+    // it should still call sendFn even when isReady() returns false, so the
+    // extension can safely issue it before the handshake completes.
+    const sent: ServerMessage[] = [];
+    const core = createBridgeCore(m => sent.push(m), () => false, noop);
+
+    core.setAutoRefresh(true, 5000);
+
+    expect(sent).toHaveLength(1);
+  });
+});
+
+// Static-source regression checks for the two Lua client files. We can't
+// run Luau code in a Bun test, but we can assert the critical structural
+// invariants that a helpful refactor could easily break:
+//  - the auto-refresh subsystem is present
+//  - the dirty flag is cleared BEFORE rebuilding (reentrancy)
+//  - the old "flood" comment is gone
+//  - cleanup runs on disconnect
+
+const readFile = (...parts: string[]): string =>
+  readFileSync(path.join(import.meta.dir, '..', ...parts), 'utf8');
+
+describe('studio-plugin gameTree.luau auto-refresh subsystem', () => {
+  const source = readFile('studio-plugin', 'src', 'handlers', 'gameTree.luau');
+
+  test('exposes gameTree.setAutoRefresh and gameTree.shutdownAutoRefresh', () => {
+    expect(/gameTree\.setAutoRefresh\s*=\s*function/.test(source)).toBe(true);
+    expect(/gameTree\.shutdownAutoRefresh\s*=\s*function/.test(source)).toBe(true);
+  });
+
+  test('uses RunService.Heartbeat for the coalesced flush gate', () => {
+    expect(/local\s+RunService\s*=\s*game:GetService['"]RunService['"]/.test(source)).toBe(true);
+    expect(/RunService\.Heartbeat:Connect/.test(source)).toBe(true);
+  });
+
+  test('listens on both DescendantAdded and DescendantRemoving', () => {
+    expect(/DescendantAdded:Connect\(markDirty\)/.test(source)).toBe(true);
+    expect(/DescendantRemoving:Connect\(markDirty\)/.test(source)).toBe(true);
+  });
+
+  test('hooks game.ChildAdded for new top-level services', () => {
+    expect(/game\.ChildAdded:Connect/.test(source)).toBe(true);
+  });
+
+  test('clears dirty state BEFORE rebuilding to preserve events during serialisation', () => {
+    // heartbeatTick must reset isDirty before calling buildTree, so a
+    // DescendantAdded firing mid-serialise re-arms the next flush.
+    const tick = source.slice(source.indexOf('local heartbeatTick'));
+    const clearsBefore = /isDirty\s*=\s*false[\s\S]*?pcall\(gameTree\.buildTree/.test(tick);
+    expect(clearsBefore).toBe(true);
+  });
+
+  test('clamps interval to MIN_INTERVAL_SEC', () => {
+    expect(/MIN_INTERVAL_SEC\s*=\s*2\.0/.test(source)).toBe(true);
+    expect(/math\.max\(MIN_INTERVAL_SEC/.test(source)).toBe(true);
+  });
+
+  test('has a max-coalesce window to prevent starvation', () => {
+    expect(/MAX_COALESCE_SEC\s*=\s*30\.0/.test(source)).toBe(true);
+  });
+});
+
+describe('studio-plugin init.server.luau auto-refresh wiring', () => {
+  const source = readFile('studio-plugin', 'src', 'init.server.luau');
+
+  test('registers MESSAGE_HANDLERS.setAutoRefresh that forwards to gameTreeHandler', () => {
+    expect(/MESSAGE_HANDLERS\.setAutoRefresh\s*=\s*function/.test(source)).toBe(true);
+    expect(/gameTreeHandler\.setAutoRefresh\(message\.enabled,\s*message\.intervalMs/.test(source)).toBe(true);
+  });
+
+  test('calls shutdownAutoRefresh on WebSocket Closed and Error', () => {
+    const closed = source.match(/wsClient\.Closed:Connect\(function\(\)[\s\S]*?end\)/);
+    const errored = source.match(/wsClient\.Error:Connect\(function\([^)]*\)[\s\S]*?end\)/);
+    expect(closed?.[0]).toContain('gameTreeHandler.shutdownAutoRefresh()');
+    expect(errored?.[0]).toContain('gameTreeHandler.shutdownAutoRefresh()');
+  });
+
+  test('hooks plugin.Unloading to dispose listeners on plugin reload', () => {
+    expect(/plugin\.Unloading:Connect/.test(source)).toBe(true);
+    // The hook must reference shutdownAutoRefresh (via the handler module).
+    const unload = source.match(/plugin\.Unloading:Connect\(function\(\)[\s\S]*?end\)/);
+    expect(unload?.[0]).toContain('gameTreeHandler.shutdownAutoRefresh()');
+  });
+});
+
+describe('executor-bridge.lua auto-refresh subsystem', () => {
+  const source = readFile('scripts', 'executor-bridge.lua');
+
+  test('no longer contains the stale "flood" comment that said listeners are forbidden', () => {
+    // Regression guard: this comment was the "grey zone" — if a helpful
+    // refactor reintroduces it, the feature has been partially reverted.
+    expect(source.includes('flood VS Code with redundant tree dumps')).toBe(false);
+    expect(source.includes('No automatic DescendantAdded/DescendantRemoving listeners')).toBe(false);
+  });
+
+  test('declares the auto-refresh state and helpers', () => {
+    expect(/local\s+autoRefreshEnabled\s*=\s*false/.test(source)).toBe(true);
+    expect(/local\s+autoRefreshIntervalSec\s*=\s*5\.0/.test(source)).toBe(true);
+    expect(/local\s+MIN_AUTO_REFRESH_INTERVAL_SEC\s*=\s*2\.0/.test(source)).toBe(true);
+    expect(/local\s+MAX_COALESCE_SEC\s*=\s*30\.0/.test(source)).toBe(true);
+  });
+
+  test('uses RunService.Heartbeat (declared at file top) for the flush gate', () => {
+    expect(/local\s+RunService\s*=\s*game:GetService['"]RunService['"]/.test(source)).toBe(true);
+    expect(/RunService\.Heartbeat:Connect\(autoRefreshHeartbeatTick\)/.test(source)).toBe(true);
+  });
+
+  test('stores RBXScriptConnections in refreshConnections so re-execution cleanup disposes them', () => {
+    // refreshConnections is the pre-wired table that the top-of-file
+    // cleanup iterates when the bridge is re-executed.
+    expect(/table\.insert\(refreshConnections,\s*addedConn\)/.test(source)).toBe(true);
+    expect(/table\.insert\(refreshConnections,\s*removingConn\)/.test(source)).toBe(true);
+    expect(/table\.insert\(refreshConnections,\s*autoRefreshHeartbeat\)/.test(source)).toBe(true);
+    expect(/table\.insert\(refreshConnections,\s*autoRefreshTopLevel\)/.test(source)).toBe(true);
+  });
+
+  test('clears refreshConnections in-place (not by reassignment) to preserve getgenv reference', () => {
+    // Reassigning `refreshConnections = {}` would leak the old table and
+    // break the re-execution cleanup at the top of the file, since
+    // getgenv()._RBXDEV_BRIDGE.refreshConnections would still point at
+    // the stale reference.
+    const detach = source.slice(source.indexOf('detachAutoRefreshListeners = function'));
+    const detachEnd = detach.indexOf('\nend\n');
+    const body = detach.slice(0, detachEnd + 5);
+    expect(/for\s+i\s*=\s*#refreshConnections,\s*1,\s*-1\s+do\s+refreshConnections\[i\]\s*=\s*nil/.test(body)).toBe(true);
+    expect(/refreshConnections\s*=\s*\{\}/.test(body)).toBe(false);
+  });
+
+  test('registers MESSAGE_HANDLERS.setAutoRefresh that forwards to setAutoRefresh()', () => {
+    expect(/MESSAGE_HANDLERS\.setAutoRefresh\s*=\s*function\(message\)[\s\S]*?setAutoRefresh\(message\.enabled,\s*message\.intervalMs\)/.test(source)).toBe(true);
+  });
+
+  test('calls shutdownAutoRefresh on ws.OnClose so listeners release on disconnect', () => {
+    const onClose = source.match(/ws\.OnClose:Connect\(function\(\)[\s\S]*?end\)/);
+    expect(onClose?.[0]).toContain('shutdownAutoRefresh()');
+  });
+
+  test('clears dirty state before serialising the tree (reentrancy)', () => {
+    const tick = source.slice(source.indexOf('autoRefreshHeartbeatTick = function'));
+    const clearsBefore = /autoRefreshDirty\s*=\s*false[\s\S]*?pcall\(getGameTree/.test(tick);
+    expect(clearsBefore).toBe(true);
+  });
+
+  test('listens on both DescendantAdded and DescendantRemoving', () => {
+    expect(/DescendantAdded:Connect\(markAutoRefreshDirty\)/.test(source)).toBe(true);
+    expect(/DescendantRemoving:Connect\(markAutoRefreshDirty\)/.test(source)).toBe(true);
+  });
+
+  test('hooks game.ChildAdded so new top-level services get listeners attached', () => {
+    const connect = source.match(/autoRefreshTopLevel\s*=\s*game\.ChildAdded:Connect\(function\(child\)[\s\S]*?end\)/);
+    expect(connect).not.toBeNull();
+    expect(connect?.[0]).toContain('attachAutoRefreshListeners(child)');
+    expect(connect?.[0]).toContain('markAutoRefreshDirty()');
+  });
+});

--- a/tests/hover-local-member.test.ts
+++ b/tests/hover-local-member.test.ts
@@ -1,0 +1,170 @@
+import { buildGlobalEnvironment } from '@definitions/globals';
+import {
+  formatMemberHoverForType,
+  resolveSymbolTypeInDocument,
+} from '@lsp/handlers/hover';
+import { parse } from '@parser/parser';
+import { checkProgram } from '@typings/checker';
+import { describe, expect, test } from 'bun:test';
+
+import type { ParsedDocument } from '@typings/lsp';
+import type { ClassType } from '@typings/types';
+
+const globalEnv = buildGlobalEnvironment();
+
+const resolveClass = (name: string): ClassType | undefined => {
+  const cls = globalEnv.robloxClasses.get(name);
+  return cls !== undefined && cls.kind === 'Class' ? cls : undefined;
+};
+
+const makeParsedDocument = (code: string): ParsedDocument => {
+  const result = parse(code);
+  const classes = new Map<string, ClassType>();
+  for (const [name, type] of globalEnv.robloxClasses) {
+    if (type.kind === 'Class') classes.set(name, type);
+  }
+  const typeCheckResult = checkProgram(result.ast, {
+    classes,
+    'dataTypes': globalEnv.robloxDataTypes,
+    'mode': 'nonstrict',
+  });
+  return {
+    'uri': 'file:///test.luau',
+    'version': 1,
+    'content': code,
+    'ast': result.ast,
+    'parseErrors': [],
+    'typeErrors': typeCheckResult.diagnostics,
+    typeCheckResult,
+  };
+};
+
+describe('resolveSymbolTypeInDocument', () => {
+  test('finds a local table literal and returns its TableType', () => {
+    const doc = makeParsedDocument(`
+local Counter = {
+  increment = function(n) return n + 1 end,
+  decrement = function(n) return n - 1 end,
+  reset = function() return 0 end,
+}
+`);
+    const t = resolveSymbolTypeInDocument(doc, 'Counter');
+    expect(t).toBeDefined();
+    expect(t?.kind).toBe('Table');
+    if (t?.kind === 'Table') {
+      expect(t.properties.has('increment')).toBe(true);
+      expect(t.properties.has('decrement')).toBe(true);
+      expect(t.properties.has('reset')).toBe(true);
+    }
+  });
+
+  test('returns undefined for an unknown symbol', () => {
+    const doc = makeParsedDocument('local x = 1');
+    expect(resolveSymbolTypeInDocument(doc, 'Counter')).toBeUndefined();
+  });
+
+  test('returns undefined when typeCheckResult is missing', () => {
+    const doc = makeParsedDocument('local x = 1');
+    const docNoCheck: ParsedDocument = { ...doc, 'typeCheckResult': undefined };
+    expect(resolveSymbolTypeInDocument(docNoCheck, 'x')).toBeUndefined();
+  });
+});
+
+describe('formatMemberHoverForType — user tables (sourcemap scenario)', () => {
+  test('returns markdown for an existing property on a TableType', () => {
+    const doc = makeParsedDocument(`
+local Counter = {
+  increment = function(n) return n + 1 end,
+}
+`);
+    const t = resolveSymbolTypeInDocument(doc, 'Counter');
+    expect(t).toBeDefined();
+    if (t === undefined) return;
+
+    const md = formatMemberHoverForType(t, 'increment', resolveClass);
+    expect(md).toBeDefined();
+    expect(md).toContain('increment');
+    // Should be wrapped in a lua code block (either via formatFunctionDocFull
+    // or the plain typeToString fallback).
+    expect(md).toContain('```lua');
+  });
+
+  test('returns undefined for a missing property on a TableType', () => {
+    const doc = makeParsedDocument('local t = { foo = 1 }');
+    const t = resolveSymbolTypeInDocument(doc, 't');
+    if (t === undefined) throw new Error('expected t in scope');
+    expect(formatMemberHoverForType(t, 'bar', resolveClass)).toBeUndefined();
+  });
+
+  test('handles a table with a value field', () => {
+    const doc = makeParsedDocument('local config = { version = 1, name = "abc" }');
+    const t = resolveSymbolTypeInDocument(doc, 'config');
+    if (t === undefined) throw new Error('expected config in scope');
+    const md = formatMemberHoverForType(t, 'version', resolveClass);
+    expect(md).toBeDefined();
+    expect(md).toContain('version');
+  });
+});
+
+describe('formatMemberHoverForType — class-typed locals', () => {
+  test('returns a property hover for a typed class local', () => {
+    const doc = makeParsedDocument(`
+local part: Part = nil :: any
+`);
+    const t = resolveSymbolTypeInDocument(doc, 'part');
+    expect(t).toBeDefined();
+    if (t === undefined) return;
+    expect(t.kind).toBe('Class');
+    if (t.kind !== 'Class') return;
+
+    const md = formatMemberHoverForType(t, 'Position', resolveClass);
+    expect(md).toBeDefined();
+    expect(md).toContain('Position');
+    expect(md).toContain('```lua');
+  });
+
+  test('returns a method hover for a typed class local', () => {
+    const doc = makeParsedDocument(`
+local inst: Instance = nil :: any
+`);
+    const t = resolveSymbolTypeInDocument(doc, 'inst');
+    expect(t).toBeDefined();
+    if (t === undefined) return;
+    if (t.kind !== 'Class') return;
+
+    const md = formatMemberHoverForType(t, 'FindFirstChild', resolveClass);
+    expect(md).toBeDefined();
+    expect(md).toContain('FindFirstChild');
+  });
+
+  test('walks the class superclass chain', () => {
+    // Part inherits from BasePart inherits from PVInstance inherits from Instance.
+    // FindFirstChild lives on Instance — should still be found via the chain.
+    const doc = makeParsedDocument(`
+local p: Part = nil :: any
+`);
+    const t = resolveSymbolTypeInDocument(doc, 'p');
+    if (t === undefined || t.kind !== 'Class') throw new Error('expected Part class in scope');
+
+    const md = formatMemberHoverForType(t, 'FindFirstChild', resolveClass);
+    expect(md).toBeDefined();
+    expect(md).toContain('FindFirstChild');
+  });
+
+  test('returns undefined for an unknown member on a class', () => {
+    const doc = makeParsedDocument('local p: Part = nil :: any');
+    const t = resolveSymbolTypeInDocument(doc, 'p');
+    if (t === undefined || t.kind !== 'Class') throw new Error('expected Part class in scope');
+    expect(formatMemberHoverForType(t, 'ThisDoesNotExist', resolveClass)).toBeUndefined();
+  });
+});
+
+describe('formatMemberHoverForType — non-applicable types', () => {
+  test('returns undefined for primitive types', () => {
+    const doc = makeParsedDocument('local n = 42');
+    const t = resolveSymbolTypeInDocument(doc, 'n');
+    expect(t).toBeDefined();
+    if (t === undefined) return;
+    expect(formatMemberHoverForType(t, 'anything', resolveClass)).toBeUndefined();
+  });
+});

--- a/tests/module-export-signatures.test.ts
+++ b/tests/module-export-signatures.test.ts
@@ -1,0 +1,224 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { resolveAnnotationToType } from '@workspace/annotationResolver';
+import { buildModuleIndex } from '@workspace/moduleIndex';
+import { loadSourcemapState } from '@workspace/sourcemap';
+import { typeToString } from '@typings/types';
+
+import type { TypeAnnotation } from '@typings/ast';
+
+const makeRef = (name: string): TypeAnnotation =>
+  ({ 'kind': 'TypeReference', name, 'module': undefined, 'typeArgs': undefined, 'range': { 'start': { 'line': 0, 'character': 0 }, 'end': { 'line': 0, 'character': 0 } } }) as unknown as TypeAnnotation;
+
+describe('resolveAnnotationToType', () => {
+  test('undefined annotation → any', () => {
+    expect(resolveAnnotationToType(undefined).kind).toBe('Any');
+  });
+
+  test('number primitive', () => {
+    const t = resolveAnnotationToType(makeRef('number'));
+    expect(t.kind).toBe('Primitive');
+    if (t.kind === 'Primitive') expect(t.name).toBe('number');
+  });
+
+  test('string primitive', () => {
+    const t = resolveAnnotationToType(makeRef('string'));
+    expect(t.kind).toBe('Primitive');
+    if (t.kind === 'Primitive') expect(t.name).toBe('string');
+  });
+
+  test('boolean primitive', () => {
+    const t = resolveAnnotationToType(makeRef('boolean'));
+    expect(t.kind).toBe('Primitive');
+    if (t.kind === 'Primitive') expect(t.name).toBe('boolean');
+  });
+
+  test('nil primitive', () => {
+    const t = resolveAnnotationToType(makeRef('nil'));
+    expect(t.kind).toBe('Primitive');
+    if (t.kind === 'Primitive') expect(t.name).toBe('nil');
+  });
+
+  test('any keyword → AnyType', () => {
+    expect(resolveAnnotationToType(makeRef('any')).kind).toBe('Any');
+  });
+
+  test('unknown keyword → UnknownType', () => {
+    expect(resolveAnnotationToType(makeRef('unknown')).kind).toBe('Unknown');
+  });
+
+  test('unrecognised class/type reference → any', () => {
+    // User type aliases, Roblox classes (Part), generics, etc. are out of
+    // reach for this lossy converter — they fall back to any.
+    expect(resolveAnnotationToType(makeRef('Part')).kind).toBe('Any');
+    expect(resolveAnnotationToType(makeRef('MyAlias')).kind).toBe('Any');
+  });
+});
+
+// End-to-end check: a real file on disk, walked through the same code path
+// the language server uses (loadSourcemapState → buildModuleIndex) and
+// observed via typeToString output. This catches regressions in the AST
+// shape the extractor walks, not just the converter in isolation.
+describe('extractModuleExports captures function signatures end-to-end', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'rbxdev-signatures-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { 'recursive': true, 'force': true });
+    } catch {
+      /* noop */
+    }
+  });
+
+  const writeFixture = (moduleSource: string): void => {
+    writeFileSync(
+      path.join(tempDir, 'default.project.json'),
+      JSON.stringify({
+        'name': 'fixture',
+        'tree': {
+          '$className': 'DataModel',
+          'ReplicatedStorage': {
+            '$className': 'ReplicatedStorage',
+            'Module': { '$path': 'src/Module.lua' },
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      path.join(tempDir, 'sourcemap.json'),
+      JSON.stringify({
+        'name': 'fixture',
+        'className': 'DataModel',
+        'children': [
+          {
+            'name': 'ReplicatedStorage',
+            'className': 'ReplicatedStorage',
+            'children': [
+              {
+                'name': 'Module',
+                'className': 'ModuleScript',
+                'filePaths': ['src/Module.lua'],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    mkdirSync(path.join(tempDir, 'src'), { 'recursive': true });
+    writeFileSync(path.join(tempDir, 'src', 'Module.lua'), moduleSource);
+  };
+
+  const loadExports = (): Map<string, { params: string; returnType: string; kind: string }> => {
+    const state = loadSourcemapState(tempDir);
+    const index = buildModuleIndex(state, tempDir);
+
+    const result = new Map<string, { params: string; returnType: string; kind: string }>();
+    for (const [, info] of index) {
+      for (const exp of info.exports) {
+        if (exp.signature === undefined) {
+          result.set(exp.name, { 'params': '', 'returnType': '', 'kind': exp.kind });
+          continue;
+        }
+        const params = exp.signature.params.map(p => `${p.name ?? '?'}: ${typeToString(p.type)}`).join(', ');
+        const returnType = typeToString(exp.signature.returnType);
+        result.set(exp.name, { params, returnType, 'kind': exp.kind });
+      }
+    }
+    return result;
+  };
+
+  test('captures FunctionDeclaration style `function Module.x(a: T): R`', () => {
+    writeFixture(`
+local Module = {}
+
+function Module.increment(value: number): number
+	return value + 1
+end
+
+function Module.reset(): number
+	return 0
+end
+
+return Module
+`);
+    const exports = loadExports();
+    expect(exports.get('increment')?.params).toBe('value: number');
+    expect(exports.get('increment')?.returnType).toBe('number');
+    expect(exports.get('reset')?.params).toBe('');
+    expect(exports.get('reset')?.returnType).toBe('number');
+  });
+
+  test('captures table-literal assignment `Module.x = function(a: T): R ... end`', () => {
+    writeFixture(`
+local Module = {
+	greet = function(name: string): string
+		return "Hello, " .. name
+	end,
+	multiply = function(a: number, b: number): number
+		return a * b
+	end,
+}
+
+return Module
+`);
+    const exports = loadExports();
+    expect(exports.get('greet')?.params).toBe('name: string');
+    expect(exports.get('greet')?.returnType).toBe('string');
+    expect(exports.get('multiply')?.params).toBe('a: number, b: number');
+    expect(exports.get('multiply')?.returnType).toBe('number');
+  });
+
+  test('captures direct table return `return { foo = function(...) end }`', () => {
+    writeFixture(`
+return {
+	negate = function(value: boolean): boolean
+		return not value
+	end,
+}
+`);
+    const exports = loadExports();
+    expect(exports.get('negate')?.params).toBe('value: boolean');
+    expect(exports.get('negate')?.returnType).toBe('boolean');
+  });
+
+  test('missing annotations fall back to any, not a synthetic `(): any`', () => {
+    writeFixture(`
+local Module = {}
+
+function Module.bare(x, y)
+	return x + y
+end
+
+return Module
+`);
+    const exports = loadExports();
+    const bare = exports.get('bare');
+    expect(bare).toBeDefined();
+    // Two params recorded with any as their type
+    expect(bare?.params).toBe('x: any, y: any');
+    expect(bare?.returnType).toBe('any');
+  });
+
+  test('return-type-only (`function Module.x(): number`)', () => {
+    writeFixture(`
+local Module = {}
+
+function Module.getConstant(): number
+	return 42
+end
+
+return Module
+`);
+    const exports = loadExports();
+    expect(exports.get('getConstant')?.params).toBe('');
+    expect(exports.get('getConstant')?.returnType).toBe('number');
+  });
+});

--- a/tests/sourcemap.test.ts
+++ b/tests/sourcemap.test.ts
@@ -1,0 +1,257 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  buildDataModelTreeFromSourcemap,
+  findSourcemap,
+  loadSourcemapState,
+  parseSourcemap,
+  type SourcemapNode,
+} from '@workspace/sourcemap';
+
+describe('sourcemap parser', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'rbxdev-sourcemap-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { 'recursive': true, 'force': true });
+    } catch {
+      /* noop */
+    }
+  });
+
+  test('findSourcemap returns undefined when no sourcemap.json exists', () => {
+    expect(findSourcemap(tempDir)).toBeUndefined();
+  });
+
+  test('findSourcemap returns the path when sourcemap.json exists at workspace root', () => {
+    const sourcemapPath = path.join(tempDir, 'sourcemap.json');
+    writeFileSync(sourcemapPath, '{}');
+    expect(findSourcemap(tempDir)).toBe(sourcemapPath);
+  });
+
+  test('parseSourcemap returns undefined for missing files', () => {
+    expect(parseSourcemap(path.join(tempDir, 'nope.json'))).toBeUndefined();
+  });
+
+  test('parseSourcemap returns undefined for invalid JSON', () => {
+    const p = path.join(tempDir, 'sourcemap.json');
+    writeFileSync(p, '{ not json');
+    expect(parseSourcemap(p)).toBeUndefined();
+  });
+
+  test('parseSourcemap returns undefined when required fields are missing', () => {
+    const p = path.join(tempDir, 'sourcemap.json');
+    writeFileSync(p, JSON.stringify({ 'className': 'DataModel' })); // missing name
+    expect(parseSourcemap(p)).toBeUndefined();
+  });
+
+  test('parseSourcemap accepts minimal valid sourcemap', () => {
+    const p = path.join(tempDir, 'sourcemap.json');
+    writeFileSync(p, JSON.stringify({ 'name': 'Root', 'className': 'DataModel' }));
+    const parsed = parseSourcemap(p);
+    expect(parsed).toBeDefined();
+    expect(parsed?.name).toBe('Root');
+    expect(parsed?.className).toBe('DataModel');
+  });
+
+  test('buildDataModelTreeFromSourcemap copies name and className verbatim', () => {
+    const root: SourcemapNode = { 'name': 'Place1', 'className': 'DataModel' };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    expect(tree.name).toBe('Place1');
+    expect(tree.className).toBe('DataModel');
+    expect(tree.children.size).toBe(0);
+    expect(tree.filePath).toBeUndefined();
+  });
+
+  test('buildDataModelTreeFromSourcemap does not hard-code DataModel as root className', () => {
+    // Library projects use Folder / ModuleScript as the root.
+    const root: SourcemapNode = { 'name': 'MyLib', 'className': 'Folder' };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    expect(tree.className).toBe('Folder');
+  });
+
+  test('buildDataModelTreeFromSourcemap recurses into children', () => {
+    const root: SourcemapNode = {
+      'name': 'Game',
+      'className': 'DataModel',
+      'children': [
+        {
+          'name': 'ReplicatedStorage',
+          'className': 'ReplicatedStorage',
+          'children': [{ 'name': 'Module', 'className': 'ModuleScript' }],
+        },
+      ],
+    };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    const rs = tree.children.get('ReplicatedStorage');
+    expect(rs).toBeDefined();
+    expect(rs?.className).toBe('ReplicatedStorage');
+    const module = rs?.children.get('Module');
+    expect(module).toBeDefined();
+    expect(module?.className).toBe('ModuleScript');
+  });
+
+  test('buildDataModelTreeFromSourcemap prefers .lua/.luau over directory path', () => {
+    // Folder-backed ModuleScript emits both the dir and the init file.
+    const root: SourcemapNode = {
+      'name': 'Root',
+      'className': 'DataModel',
+      'children': [
+        {
+          'name': 'FolderModule',
+          'className': 'ModuleScript',
+          'filePaths': ['src/FolderModule', 'src/FolderModule/init.lua'],
+        },
+      ],
+    };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    const child = tree.children.get('FolderModule');
+    expect(child).toBeDefined();
+    expect(child?.filePath).toBe(path.normalize(path.join(tempDir, 'src/FolderModule/init.lua')));
+  });
+
+  test('buildDataModelTreeFromSourcemap resolves relative paths against baseDir', () => {
+    const root: SourcemapNode = {
+      'name': 'Root',
+      'className': 'DataModel',
+      'children': [
+        {
+          'name': 'Module',
+          'className': 'ModuleScript',
+          'filePaths': ['src/Module.lua'],
+        },
+      ],
+    };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    const child = tree.children.get('Module');
+    expect(child?.filePath).toBe(path.normalize(path.join(tempDir, 'src/Module.lua')));
+  });
+
+  test('buildDataModelTreeFromSourcemap preserves absolute paths', () => {
+    const absolute = path.normalize(path.join(tempDir, 'absolute', 'Module.lua'));
+    const root: SourcemapNode = {
+      'name': 'Root',
+      'className': 'DataModel',
+      'children': [
+        {
+          'name': 'Module',
+          'className': 'ModuleScript',
+          'filePaths': [absolute],
+        },
+      ],
+    };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    expect(tree.children.get('Module')?.filePath).toBe(absolute);
+  });
+
+  test('buildDataModelTreeFromSourcemap keeps first child when duplicate names exist', () => {
+    const root: SourcemapNode = {
+      'name': 'Root',
+      'className': 'DataModel',
+      'children': [
+        { 'name': 'Foo', 'className': 'Folder' },
+        { 'name': 'Foo', 'className': 'ModuleScript' },
+      ],
+    };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    expect(tree.children.size).toBe(1);
+    expect(tree.children.get('Foo')?.className).toBe('Folder');
+  });
+
+  test('buildDataModelTreeFromSourcemap leaves filePath undefined when filePaths is missing', () => {
+    const root: SourcemapNode = {
+      'name': 'Root',
+      'className': 'DataModel',
+      'children': [{ 'name': 'Service', 'className': 'ReplicatedStorage' }],
+    };
+    const tree = buildDataModelTreeFromSourcemap(root, tempDir);
+    expect(tree.children.get('Service')?.filePath).toBeUndefined();
+  });
+
+  test('loadSourcemapState returns empty state when sourcemap.json is missing', () => {
+    const state = loadSourcemapState(tempDir);
+    expect(state.dataModel).toBeUndefined();
+    expect(state.projectPath).toBeUndefined();
+    expect(state.project).toBeUndefined();
+  });
+
+  test('loadSourcemapState returns projectPath but no dataModel when file is invalid', () => {
+    const p = path.join(tempDir, 'sourcemap.json');
+    writeFileSync(p, '{ broken');
+    const state = loadSourcemapState(tempDir);
+    expect(state.dataModel).toBeUndefined();
+    expect(state.projectPath).toBe(p);
+  });
+
+  test('loadSourcemapState builds a DataModelNode tree from a valid file', () => {
+    const p = path.join(tempDir, 'sourcemap.json');
+    mkdirSync(path.join(tempDir, 'src'), { 'recursive': true });
+    writeFileSync(path.join(tempDir, 'src', 'Module.lua'), '-- empty\n');
+    writeFileSync(
+      p,
+      JSON.stringify({
+        'name': 'Place1',
+        'className': 'DataModel',
+        'children': [
+          {
+            'name': 'ReplicatedStorage',
+            'className': 'ReplicatedStorage',
+            'children': [
+              {
+                'name': 'Module',
+                'className': 'ModuleScript',
+                'filePaths': ['src/Module.lua'],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const state = loadSourcemapState(tempDir);
+    expect(state.dataModel).toBeDefined();
+    expect(state.projectPath).toBe(p);
+    expect(state.project).toBeUndefined();
+
+    const rs = state.dataModel?.children.get('ReplicatedStorage');
+    expect(rs).toBeDefined();
+    const module = rs?.children.get('Module');
+    expect(module?.filePath).toBe(path.normalize(path.join(tempDir, 'src/Module.lua')));
+  });
+
+  test('loadSourcemapState uses the sourcemap directory as the path base', () => {
+    // Put the sourcemap in a subdirectory; filePaths resolve against that
+    // subdirectory, not the workspace root.
+    const project = path.join(tempDir, 'game');
+    mkdirSync(project, { 'recursive': true });
+    mkdirSync(path.join(project, 'src'), { 'recursive': true });
+    writeFileSync(path.join(project, 'src', 'Module.lua'), '');
+    writeFileSync(
+      path.join(project, 'sourcemap.json'),
+      JSON.stringify({
+        'name': 'Root',
+        'className': 'DataModel',
+        'children': [
+          {
+            'name': 'M',
+            'className': 'ModuleScript',
+            'filePaths': ['src/Module.lua'],
+          },
+        ],
+      }),
+    );
+
+    const state = loadSourcemapState(project);
+    expect(state.dataModel?.children.get('M')?.filePath).toBe(
+      path.normalize(path.join(project, 'src/Module.lua')),
+    );
+  });
+});

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -542,6 +542,17 @@
           "type": "boolean",
           "default": false,
           "description": "Enable verbose debug logging in the extension output/devtools console"
+        },
+        "rbxdev-ls.autoRefreshGameTree.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically refresh the game tree when instances are added or removed in Studio or the connected executor. Opt-in because it adds main-thread cost in Studio on bursty edits; listeners do a single flag write and flushes are debounced."
+        },
+        "rbxdev-ls.autoRefreshGameTree.intervalMs": {
+          "type": "number",
+          "default": 5000,
+          "minimum": 2000,
+          "description": "Debounce window for auto-refresh (milliseconds). Lower values give fresher trees at higher serialisation cost. Clamped to a 2000 ms minimum."
         }
       }
     },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -124,6 +124,19 @@ const updateStatusBar = (status: BridgeStatus, executorName?: string, clientType
   }
 };
 
+const applyAutoRefreshSetting = async (): Promise<void> => {
+  if (client === undefined) return;
+  const config = workspace.getConfiguration('rbxdev-ls');
+  const enabled = config.get<boolean>('autoRefreshGameTree.enabled', false);
+  const rawInterval = config.get<number>('autoRefreshGameTree.intervalMs', 5000);
+  const intervalMs = Math.max(2000, Math.floor(rawInterval));
+  try {
+    await client.sendRequest('custom/setAutoRefresh', { enabled, intervalMs });
+  } catch (err) {
+    logDebug('[rbxdev-ls] setAutoRefresh request failed:', err);
+  }
+};
+
 const pollExecutorStatus = async (): Promise<void> => {
   if (client === undefined) return;
   if (isPollingExecutorStatus === true) return;
@@ -143,6 +156,7 @@ const pollExecutorStatus = async (): Promise<void> => {
       commands.executeCommand('setContext', 'rbxdev-ls:bridgeConnected', true);
       commands.executeCommand('setContext', 'rbxdev-ls:clientType', currentClientType ?? 'executor');
       void syncRemoteSpyStateToExecutor();
+      void applyAutoRefreshSetting();
     } else if (response.isConnected === false && lastConnectedState) {
       const label = lastClientType === 'studio' ? 'Roblox Studio' : (lastExecutorName ?? 'Client');
       window.showWarningMessage(`Roblox: ${label} disconnected`);
@@ -643,6 +657,14 @@ export const activate = (context: ExtensionContext): void => {
         else window.showErrorMessage(`Push to Studio failed: ${result.error ?? 'Unknown error'}`);
       } catch (err) {
         window.showErrorMessage(`Push to Studio failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('rbxdev-ls.autoRefreshGameTree')) {
+        void applyAutoRefreshSetting();
       }
     }),
   );


### PR DESCRIPTION
Closes #9

## Summary
- add Rojo `sourcemap.json` workspace discovery alongside `default.project.json`. sourcemap wins if both exist, and the LSP watches it with a debounced `fs.watch` so edits reload the module index + diagnostics
- capture real function signatures in the module index instead of emitting the synthetic `() -> any` we used to. lossy `TypeAnnotation → LuauType` converter in `src/workspace/annotationResolver.ts` handles primitives, optional, flat unions; anything else falls back to `any`. `Counter.increment` now hovers as `function increment(value: number): number`
- surface hover for user-defined tables and class-typed locals by walking document scopes in `src/lsp/handlers/hover.ts`. also fixes the standalone case where `local part: BasePart = ...; part.Position` had no hover
- add opt-in auto-refresh for the in-game instance tree, shipped in both `studio-plugin/src/handlers/gameTree.luau` and `scripts/executor-bridge.lua`. descendant listeners do a single flag write; `RunService.Heartbeat` gates the flush on a coalescing deadline so model pastes and respawn bursts coalesce into one tree push per window. 30s max-coalesce, 2s minimum interval, default off. replaces the old "no listeners at all" policy at `scripts/executor-bridge.lua:719-721`
- executor side uses the pre-wired `getgenv()._RBXDEV_BRIDGE.refreshConnections` table for cleanup on re-execution (cleared in-place so the genv reference stays valid). studio side hooks `plugin.Unloading` for the same purpose — first use of that hook in this plugin
- two new extension settings: `rbxdev-ls.autoRefreshGameTree.enabled` (default false) and `.intervalMs` (default 5000, min 2000). applied on bridge-connected transitions and on configuration change

## Testing
- `bun run type-check`, `bun run lint:check`, `bun run build:all` all clean
- `bun test` 984 pass / 0 fail (65 new)
- smoke-tested the sourcemap path end-to-end against a tmpdir rojo project: discovery, hover, completion, file watcher reload, rojo fallback
- studio auto-refresh path exercisable with the rebuilt `.rbxm`; executor path blocked on exploits coming back from the recent Roblox client update but shares the same LSP wiring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic game tree refresh with configurable update intervals
  * Workspace support for sourcemap.json configuration files
  * Enhanced hover tooltips for locally-declared symbols with type information
  * Function signature detection for module exports
  * New VS Code extension settings to control auto-refresh behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->